### PR TITLE
Fixes; keyboard and mouse autoconnect and keyboard grab (steal from the Pi).

### DIFF
--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -350,6 +350,8 @@ struct emulator_config *load_config_file(char *filename) {
         strcpy(cfg->mouse_file, cur_cmd);
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
         cfg->mouse_toggle_key = cur_cmd[0];
+        get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+        cfg->mouse_autoconnect = (strcmp(cur_cmd, "autoconnect") == 0) ? 1 : 0;
         cfg->mouse_enabled = 1;
         printf("[CFG] Enabled mouse event forwarding from file %s, toggle key %c.\n", cfg->mouse_file, cfg->mouse_toggle_key);
         break;
@@ -358,8 +360,14 @@ struct emulator_config *load_config_file(char *filename) {
         cfg->keyboard_toggle_key = cur_cmd[0];
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
         cfg->keyboard_grab = (strcmp(cur_cmd, "grab") == 0) ? 1 : 0;
-        printf("[CFG] Enabled keyboard event forwarding, toggle key %c, %slocking from host.\n",
-               cfg->keyboard_toggle_key, cfg->keyboard_grab ? "" : "not ");
+        get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+        cfg->keyboard_autoconnect = (strcmp(cur_cmd, "autoconnect") == 0) ? 1 : 0;
+        printf("[CFG] Enabled keyboard event forwarding, toggle key %c", cfg->keyboard_toggle_key);
+        if (cfg->keyboard_grab)
+          printf(", locking from host when connected");
+        if (cfg->keyboard_autoconnect)
+          printf(", connected to guest at startup");
+        printf(".\n");
         break;
       case CONFITEM_KBFILE:
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');

--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -61,12 +61,12 @@ int get_config_item_type(char *cmd) {
 unsigned int get_m68k_cpu_type(char *name) {
   for (int i = 0; i < M68K_CPU_TYPES; i++) {
     if (strcmp(name, cpu_types[i]) == 0) {
-      printf("Set CPU type to %s.\n", cpu_types[i]);
+      printf("[CFG] Set CPU type to %s.\n", cpu_types[i]);
       return i + 1;
     }
   }
 
-  printf ("Invalid CPU type %s specified, defaulting to 68000.\n", name);
+  printf("[CFG] Invalid CPU type %s specified, defaulting to 68000.\n", name);
   return M68K_CPU_TYPE_68000;
 }
 
@@ -119,7 +119,7 @@ unsigned int get_int(char *str) {
           case 'M': ret_int = ret_int * SIZE_MEGA; break;
           case 'G': ret_int = ret_int * SIZE_GIGA; break;
           default:
-            printf("Unknown character %c in hex value.\n", str[i]);
+            printf("[CFG] Unknown character %c in hex value.\n", str[i]);
             break;
         }
       }
@@ -179,7 +179,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
     index++;
   }
   if (index == MAX_NUM_MAPPED_ITEMS) {
-    printf("Unable to map item, only %d items can be mapped with current binary.\n", MAX_NUM_MAPPED_ITEMS);
+    printf("[CFG] Unable to map item, only %d items can be mapped with current binary.\n", MAX_NUM_MAPPED_ITEMS);
     return;
   }
 
@@ -195,10 +195,10 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
 
   switch(type) {
     case MAPTYPE_RAM:
-      printf("Allocating %d bytes for RAM mapping (%d MB)...\n", size, size / 1024 / 1024);
+      printf("[CFG] Allocating %d bytes for RAM mapping (%d MB)...\n", size, size / 1024 / 1024);
       cfg->map_data[index] = (unsigned char *)malloc(size);
       if (!cfg->map_data[index]) {
-        printf("ERROR: Unable to allocate memory for mapped RAM!\n");
+        printf("[CFG] ERROR: Unable to allocate memory for mapped RAM!\n");
         goto mapping_failed;
       }
       memset(cfg->map_data[index], 0x00, size);
@@ -206,7 +206,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
     case MAPTYPE_ROM:
       in = fopen(filename, "rb");
       if (!in) {
-        printf("Failed to open file %s for ROM mapping.\n", filename);
+        printf("[CFG] Failed to open file %s for ROM mapping.\n", filename);
         goto mapping_failed;
       }
       fseek(in, 0, SEEK_END);
@@ -219,7 +219,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
       cfg->map_data[index] = (unsigned char *)calloc(1, cfg->map_size[index]);
       cfg->rom_size[index] = (cfg->map_size[index] <= file_size) ? cfg->map_size[index] : file_size;
       if (!cfg->map_data[index]) {
-        printf("ERROR: Unable to allocate memory for mapped ROM!\n");
+        printf("[CFG] ERROR: Unable to allocate memory for mapped ROM!\n");
         goto mapping_failed;
       }
       memset(cfg->map_data[index], 0x00, cfg->map_size[index]);
@@ -231,7 +231,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
       break;
   }
 
-  printf("[MAP %d] Added %s mapping for range %.8lX-%.8lX ID: %s\n", index, map_type_names[type], cfg->map_offset[index], cfg->map_high[index] - 1, cfg->map_id[index] ? cfg->map_id[index] : "None");
+  printf("[CFG] [MAP %d] Added %s mapping for range %.8lX-%.8lX ID: %s\n", index, map_type_names[type], cfg->map_offset[index], cfg->map_high[index] - 1, cfg->map_id[index] ? cfg->map_id[index] : "None");
   if (cfg->map_size[index] == cfg->rom_size[index])
     m68k_add_rom_range(cfg->map_offset[index], cfg->map_high[index], cfg->map_data[index]);
 
@@ -246,7 +246,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
 struct emulator_config *load_config_file(char *filename) {
   FILE *in = fopen(filename, "rb");
   if (in == NULL) {
-    printf("Failed to open config file %s for reading.\n", filename);
+    printf("[CFG] Failed to open config file %s for reading.\n", filename);
     return NULL;
   }
 
@@ -257,12 +257,12 @@ struct emulator_config *load_config_file(char *filename) {
 
   parse_line = (char *)calloc(1, 512);
   if (!parse_line) {
-    printf("Failed to allocate memory for config file line buffer.\n");
+    printf("[CFG] Failed to allocate memory for config file line buffer.\n");
     return NULL;
   }
   cfg = (struct emulator_config *)calloc(1, sizeof(struct emulator_config));
   if (!cfg) {
-    printf("Failed to allocate memory for temporary emulator config.\n");
+    printf("[CFG] Failed to allocate memory for temporary emulator config.\n");
     goto load_failed;
   }
 
@@ -332,7 +332,7 @@ struct emulator_config *load_config_file(char *filename) {
               mirraddr = get_int(cur_cmd);
               break;
             default:
-              printf("Unknown/unhandled map argument %s on line %d.\n", cur_cmd, cur_line);
+              printf("[CFG] Unknown/unhandled map argument %s on line %d.\n", cur_cmd, cur_line);
               break;
           }
         }
@@ -342,7 +342,7 @@ struct emulator_config *load_config_file(char *filename) {
       }
       case CONFITEM_LOOPCYCLES:
         cfg->loop_cycles = get_int(parse_line + str_pos);
-        printf("Set CPU loop cycles to %d.\n", cfg->loop_cycles);
+        printf("[CFG] Set CPU loop cycles to %d.\n", cfg->loop_cycles);
         break;
       case CONFITEM_MOUSE:
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
@@ -351,28 +351,28 @@ struct emulator_config *load_config_file(char *filename) {
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
         cfg->mouse_toggle_key = cur_cmd[0];
         cfg->mouse_enabled = 1;
-        printf("Enabled mouse event forwarding from file %s, toggle key %c.\n", cfg->mouse_file, cfg->mouse_toggle_key);
+        printf("[CFG] Enabled mouse event forwarding from file %s, toggle key %c.\n", cfg->mouse_file, cfg->mouse_toggle_key);
         break;
       case CONFITEM_KEYBOARD:
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
         cfg->keyboard_toggle_key = cur_cmd[0];
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
         cfg->keyboard_grab = (strcmp(cur_cmd, "grab") == 0) ? 1 : 0;
-        printf("Enabled keyboard event forwarding, toggle key %c, %slocking from host.\n",
+        printf("[CFG] Enabled keyboard event forwarding, toggle key %c, %slocking from host.\n",
                cfg->keyboard_toggle_key, cfg->keyboard_grab ? "" : "not ");
         break;
       case CONFITEM_KBFILE:
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
         cfg->keyboard_file = (char *)calloc(1, strlen(cur_cmd) + 1);
         strcpy(cfg->keyboard_file, cur_cmd);
-        printf("Set keyboard event source file to %s.\n", cfg->keyboard_file);
+        printf("[CFG] Set keyboard event source file to %s.\n", cfg->keyboard_file);
         break;
       case CONFITEM_PLATFORM: {
         char platform_name[128], platform_sub[128];
         memset(platform_name, 0x00, 128);
         memset(platform_sub, 0x00, 128);
         get_next_string(parse_line, platform_name, &str_pos, ' ');
-        printf("Setting platform to %s", platform_name);
+        printf("[CFG] Setting platform to %s", platform_name);
         get_next_string(parse_line, platform_sub, &str_pos, ' ');
         if (strlen(platform_sub))
           printf(" (sub: %s)", platform_sub);
@@ -382,7 +382,7 @@ struct emulator_config *load_config_file(char *filename) {
       }
       case CONFITEM_SETVAR: {
         if (!cfg->platform) {
-          printf("Warning: esetvar used in config file with no platform specified.\n");
+          printf("[CFG] Warning: setvar used in config file with no platform specified.\n");
           break;
         }
 
@@ -397,7 +397,7 @@ struct emulator_config *load_config_file(char *filename) {
       }
       case CONFITEM_NONE:
       default:
-        printf("Unknown config item %s on line %d.\n", cur_cmd, cur_line);
+        printf("[CFG] Unknown config item %s on line %d.\n", cur_cmd, cur_line);
         break;
     }
 

--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -401,7 +401,7 @@ struct emulator_config *load_config_file(char *filename) {
         break;
     }
 
-    skip_line:;
+  skip_line:
     cur_line++;
   }
   goto load_successful;

--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -355,9 +355,11 @@ struct emulator_config *load_config_file(char *filename) {
         break;
       case CONFITEM_KEYBOARD:
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');
-        cfg->keyboard_file = (char *)calloc(1, strlen(cur_cmd) + 1);
         cfg->keyboard_toggle_key = cur_cmd[0];
-        printf("Enabled keyboard event forwarding, toggle key %c.\n", cfg->keyboard_toggle_key);
+        get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+        cfg->keyboard_grab = (strcmp(cur_cmd, "grab") == 0) ? 1 : 0;
+        printf("Enabled keyboard event forwarding, toggle key %c, %slocking from host.\n",
+               cfg->keyboard_toggle_key, cfg->keyboard_grab ? "" : "not ");
         break;
       case CONFITEM_KBFILE:
         get_next_string(parse_line, cur_cmd, &str_pos, ' ');

--- a/config_file/config_file.h
+++ b/config_file/config_file.h
@@ -68,7 +68,7 @@ struct emulator_config {
   char *mouse_file, *keyboard_file;
 
   char mouse_toggle_key, keyboard_toggle_key;
-  unsigned char mouse_enabled, keyboard_enabled;
+  unsigned char mouse_enabled, keyboard_enabled, keyboard_grab;
 
   unsigned int loop_cycles;
   unsigned int mapped_low, mapped_high;

--- a/config_file/config_file.h
+++ b/config_file/config_file.h
@@ -68,7 +68,7 @@ struct emulator_config {
   char *mouse_file, *keyboard_file;
 
   char mouse_toggle_key, keyboard_toggle_key;
-  unsigned char mouse_enabled, keyboard_enabled, keyboard_grab;
+  unsigned char mouse_enabled, mouse_autoconnect, keyboard_enabled, keyboard_grab, keyboard_autoconnect;
 
   unsigned int loop_cycles;
   unsigned int mapped_low, mapped_high;

--- a/default.cfg
+++ b/default.cfg
@@ -42,14 +42,18 @@ platform amiga
 # Uncomment this line to enable the (currently non-working) Pi-Net interface.
 #setvar pi-net
 
-# Forward mouse events to host system, defaults to off unless toggle key is pressed on the Pi.
-# Syntax is mouse [device] [toggle key]
-#mouse /dev/input/mouse0 m
 # Forward keyboard events to host system, defaults to off unless toggle key is pressed, toggled off using F12.
-# Add the keyword "grab" to steal the keyboard from the Pi, so Amiga input does not appear on the console or in X11.
-# (also helps prevent sending any ctrl-alt-del to the Amiga from resetting the Pi)
-keyboard k grab
+# Syntax: keyboard [grab key] [grab|nograb] [autoconnect|noautoconnect]
+#   "grab" steals the keyboard from the Pi so Amiga/etc. input is not sent to the Pi
+#   (also helps prevent sending any ctrl-alt-del to the Amiga from resetting the Pi)
+#
+#   "autoconnect" connects the keyboard to the Amiga/etc. on startup
+keyboard k nograb noautoconnect
 # Select a specific filename for the keyboard event source.
 # This is typically /dev/input/event1 or event0, but it may be event3 with for instance a wireless keyboard.
 # Use ls /dev/input/event* to check which event files are available and try until you find the one that works.
 #kbfile /dev/input/event1
+# Forward mouse events to host system, defaults to off unless toggle key is pressed on the Pi.
+# Syntax is mouse [device] [toggle key] [autoconnect|noautoconnect]
+# (see "keyboard" above for autoconnect description)
+mouse /dev/input/mice m noautoconnect

--- a/default.cfg
+++ b/default.cfg
@@ -46,7 +46,9 @@ platform amiga
 # Syntax is mouse [device] [toggle key]
 #mouse /dev/input/mouse0 m
 # Forward keyboard events to host system, defaults to off unless toggle key is pressed, toggled off using F12.
-#keyboard k
+# Add the keyword "grab" to steal the keyboard from the Pi, so Amiga input does not appear on the console or in X11.
+# (also helps prevent sending any ctrl-alt-del to the Amiga from resetting the Pi)
+keyboard k grab
 # Select a specific filename for the keyboard event source.
 # This is typically /dev/input/event1 or event0, but it may be event3 with for instance a wireless keyboard.
 # Use ls /dev/input/event* to check which event files are available and try until you find the one that works.

--- a/emulator.c
+++ b/emulator.c
@@ -263,7 +263,7 @@ cpu_loop:
 
   goto cpu_loop;
 
-//stop_cpu_emulation:
+stop_cpu_emulation:
   printf("[CPU] End of CPU thread\n");
 }
 

--- a/emulator.c
+++ b/emulator.c
@@ -59,7 +59,6 @@ extern volatile uint16_t srdata;
 extern uint8_t realtime_graphics_debug;
 uint8_t realtime_disassembly, int2_enabled = 0;
 uint32_t do_disasm = 0, old_level;
-char c = 0, c_code = 0, c_type = 0; // @todo temporary main/cpu_task scope workaround until input moved to a thread
 uint32_t last_irq = 8, last_last_irq = 8;
 
 char disasm_buf[4096];
@@ -265,6 +264,7 @@ cpu_loop:
 void *keyboard_task() {
   struct pollfd kbdpoll[1];
   int kpollrc;
+  char c = 0, c_code = 0, c_type = 0;
   char grab_message[] = "[KBD] Grabbing keyboard from input layer\n",
        ungrab_message[] = "[KBD] Ungrabbing keyboard\n";
 

--- a/emulator.c
+++ b/emulator.c
@@ -350,7 +350,8 @@ key_loop:
       }
       if (c == 'q') {
         printf("Quitting and exiting emulator.\n");
-	end_signal = 1;
+	      end_signal = 1;
+        goto key_end;
       }
       if (c == 'd') {
         realtime_disassembly ^= 1;
@@ -379,6 +380,10 @@ key_loop:
 
 key_end:
   printf("[KBD] Keyboard thread ending\n");
+  if (cfg->keyboard_grab) {
+    printf(ungrab_message);
+    release_device(keyboard_fd);
+  }
   return (void*)NULL;
 }
 

--- a/emulator.c
+++ b/emulator.c
@@ -264,6 +264,7 @@ cpu_loop:
 
 stop_cpu_emulation:
   printf("[CPU] End of CPU thread\n");
+  return (void *)NULL;
 }
 
 void *keyboard_task() {

--- a/emulator.c
+++ b/emulator.c
@@ -61,6 +61,8 @@ uint8_t realtime_disassembly, int2_enabled = 0;
 uint32_t do_disasm = 0, old_level;
 uint32_t last_irq = 8, last_last_irq = 8;
 
+uint8_t end_signal = 0;
+
 char disasm_buf[4096];
 
 #define KICKBASE 0xF80000
@@ -255,6 +257,10 @@ cpu_loop:
     // dampen the scroll wheel until next while loop iteration
     mouse_extra = 0x00;
   }
+
+  if (end_signal)
+	  goto stop_cpu_emulation;
+
   goto cpu_loop;
 
 //stop_cpu_emulation:
@@ -342,11 +348,10 @@ key_loop:
         //m68k_pulse_reset();
         printf("CPU emulation reset.\n");
       }
-      // @todo work out how to signal the main process that we want to quit
-      // if (c == 'q') {
-      //   printf("Quitting and exiting emulator.\n");
-      //   goto stop_cpu_emulation;
-      // }
+      if (c == 'q') {
+        printf("Quitting and exiting emulator.\n");
+	end_signal = 1;
+      }
       if (c == 'd') {
         realtime_disassembly ^= 1;
         do_disasm = 1;

--- a/emulator.c
+++ b/emulator.c
@@ -240,7 +240,6 @@ cpu_loop:
 //    printf("CPU emulation reset.\n");
   }
 
-
   if (mouse_hook_enabled && (mouse_extra != 0x00)) {
     // mouse wheel events have occurred; unlike l/m/r buttons, these are queued as keypresses, so add to end of buffer
     switch (mouse_extra) {
@@ -519,6 +518,12 @@ int main(int argc, char *argv[]) {
   if (keyboard_fd == -1) {
     printf("Failed to open keyboard event source.\n");
   }
+
+  if (cfg->mouse_autoconnect)
+    mouse_hook_enabled = 1;
+
+  if (cfg->keyboard_autoconnect)
+    kb_hook_enabled = 1;
 
   InitGayle();
 

--- a/input/input.c
+++ b/input/input.c
@@ -1,4 +1,5 @@
 #include <linux/input.h>
+#include <sys/ioctl.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -210,4 +211,16 @@ void pop_queued_key(uint8_t *c, uint8_t *t) {
   queue_input_pos++;
   queued_keypresses--;
   return;
+}
+
+int grab_device(int fd) {
+  int rc = 0;
+  rc = ioctl(fd, EVIOCGRAB, (void *)1);
+  return rc;
+}
+
+int release_device(int fd) {
+  int rc = 0;
+  rc = ioctl(fd, EVIOCGRAB, (void *)0);
+  return rc;
 }

--- a/input/input.h
+++ b/input/input.h
@@ -11,3 +11,5 @@ int get_key_char(char *c, char *code, char *event_type);
 int queue_keypress(uint8_t keycode, uint8_t event_type, uint8_t platform);
 int get_num_kb_queued();
 void pop_queued_key(uint8_t *c, uint8_t *t);
+int grab_device(int fd);
+int release_device(int fd);


### PR DESCRIPTION
Hello! About time for another PR. Some changes!

* Prefix config parsing output with `[CFG]` so the output is slightly clearer to the user where it's coming from.
* Move keyboard variables into `keyboard_task` function because they're not needed in global scope.
* Emulation can quit again; your 'q' key will breathe a sigh of relief (also reinstates `stop_cpu_emulation` label for goto purposes).
* Kill the warning about reaching end of `void *` function in `cpu_task`.
* Autoconnection! Your mouse and keyboard can optionally be autoconnected to the pistorm guest on startup, meaning no need to press 'k' or 'm' to attach a keyboard and mouse. Autoconnect is turned off by default in the config.
* Theft! Use of the 'grab' keyword in the keyboard config item will now ensure no input is sent to the Pi when the keyboard is attached; so no more accidental `rm *` on the Amiga causing headaches and sadness. You can ctrl-alt-del in the Amiga with reckless abandon. However, hit F12 and your Pi will receive input again. 'k' and it's stolen for the Amiga again. This can go on forever! Turned off by default in the config.

Please enjoy these changes with a fine piece of cheese 🧀 