### PR TITLE
Identify and fix byte-swapped ROMs

### DIFF
--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -251,7 +251,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
       memset(cfg->map_data[index], 0x00, cfg->map_size[index]);
       fread(cfg->map_data[index], cfg->rom_size[index], 1, in);
       fclose(in);
-      displayRomInfo(cfg->map_data[index]);
+      displayRomInfo(cfg->map_data[index], cfg->rom_size[index]);
       if (cfg->map_size[index] == cfg->rom_size[index])
         m68k_add_rom_range(cfg->map_offset[index], cfg->map_high[index], cfg->map_data[index]);
       break;

--- a/config_file/rominfo.h
+++ b/config_file/rominfo.h
@@ -26,5 +26,5 @@ enum romErrCode {
     ERR_ROM_UNKNOWN
 };
 
-void displayRomInfo(uint8_t *address);
+void displayRomInfo(uint8_t *address, size_t length);
 #endif /* __ROMINFO */


### PR DESCRIPTION
Logs and byte swaps ROMs back if byte swapped versions are found.