### PR TITLE
Fixes to allow a314 configuration on non default paths

### DIFF
--- a/a314/files_pi/a314fs.py
+++ b/a314/files_pi/a314fs.py
@@ -17,7 +17,11 @@ logging.basicConfig(format = '%(levelname)s, %(asctime)s, %(name)s, line %(linen
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-CONFIG_FILE_PATH = 'a314/files_pi/a314fs.conf'
+try:
+    idx = sys.argv.index('-conf-file')
+    CONFIG_FILE_PATH = sys.argv[idx + 1]
+except (ValueError, IndexError):
+    CONFIG_FILE_PATH = 'a314/files_pi/a314fs.conf'
 
 SHARED_DIRECTORY = 'data/a314shared'
 METAFILE_EXTENSION = ':a314'

--- a/platforms/amiga/amiga-platform.c
+++ b/platforms/amiga/amiga-platform.c
@@ -449,7 +449,7 @@ void setvar_amiga(struct emulator_config *cfg, char *var, char *val) {
             a314_emulation_enabled = 1;
         }
     }
-    if CHKVAR("a314conf") {
+    if CHKVAR("a314_conf") {
         if (val && strlen(val) != 0) {
             a314_set_config_file(val);
         }


### PR DESCRIPTION
I did 2 minor changes that allow the usage of non standard paths for the a314 config files. 

1) There was a mismatch on the pistorm config file and code that process it. On the file the variable was called a314_conf, while in the code it was called a314conf (no dash).
2) Added an optional parameter that allow the user to specify the path of the a314fs.conf. E.g. in the a314d.conf

`a314fs		python3	/home/pi/pistorm/a314/files_pi/a314fs.py -conf-file /home/pi/amiga-files/config/a314fs.conf`