### PR TITLE
Pass around a m68i_cpu_core pointer instead of accessing it as a global variable

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -567,7 +567,7 @@ switch_config:
 
   m68k_init();
   printf("Setting CPU type to %d.\n", cpu_type);
-  m68k_set_cpu_type(cpu_type);
+	m68k_set_cpu_type(&m68ki_cpu, cpu_type);
   cpu_pulse_reset();
 
   pthread_t ipl_tid = 0, cpu_tid, kbd_tid;

--- a/emulator.c
+++ b/emulator.c
@@ -181,7 +181,8 @@ void *ipl_task(void *args) {
 }
 
 void *cpu_task() {
-  m68k_pulse_reset();
+	m68ki_cpu_core *state = &m68ki_cpu;
+	m68k_pulse_reset(state);
 
 cpu_loop:
   if (mouse_hook_enabled) {
@@ -197,14 +198,14 @@ cpu_loop:
     printf("%.8X (%.8X)]] %s\n", m68k_get_reg(NULL, M68K_REG_PC), (m68k_get_reg(NULL, M68K_REG_PC) & 0xFFFFFF), disasm_buf);
     if (do_disasm)
       do_disasm--;
-    m68k_execute(1);
+	  m68k_execute(state, 1);
   }
   else {
     if (cpu_emulation_running) {
-      if (irq)
-        m68k_execute(5);
-      else
-        m68k_execute(loop_cycles);
+		if (irq)
+			m68k_execute(state, 5);
+		else
+			m68k_execute(state, loop_cycles);
     }
   }
 
@@ -626,6 +627,7 @@ switch_config:
 }
 
 void cpu_pulse_reset(void) {
+	m68ki_cpu_core *state = &m68ki_cpu;
   ps_pulse_reset();
   if (cfg->platform->handle_reset)
     cfg->platform->handle_reset(cfg);
@@ -635,7 +637,7 @@ void cpu_pulse_reset(void) {
   //m68k_write_memory_8(0xbfe201, 0x0001);  // AMIGA OVL
   //m68k_write_memory_8(0xbfe001, 0x0001);  // AMIGA OVL high (ROM@0x0)
 
-  m68k_pulse_reset();
+	m68k_pulse_reset(state);
 }
 
 int cpu_irq_ack(int level) {

--- a/m68k.h
+++ b/m68k.h
@@ -191,13 +191,13 @@ unsigned int  m68k_read_memory_16(unsigned int address);
 unsigned int  m68k_read_memory_32(unsigned int address);
 
 /* Read data immediately following the PC */
-unsigned int  m68k_read_immediate_16(unsigned int address);
-unsigned int  m68k_read_immediate_32(unsigned int address);
+unsigned int m68k_read_immediate_16(struct m68ki_cpu_core *state, unsigned int address);
+unsigned int m68k_read_immediate_32(struct m68ki_cpu_core *state, unsigned int address);
 
 /* Read data relative to the PC */
-unsigned int  m68k_read_pcrelative_8(unsigned int address);
-unsigned int  m68k_read_pcrelative_16(unsigned int address);
-unsigned int  m68k_read_pcrelative_32(unsigned int address);
+unsigned int m68k_read_pcrelative_8(struct m68ki_cpu_core *state, unsigned int address);
+unsigned int  m68k_read_pcrelative_16(struct m68ki_cpu_core *state, unsigned int address);
+unsigned int  m68k_read_pcrelative_32(struct m68ki_cpu_core *state, unsigned int address);
 
 /* Memory access for the disassembler */
 unsigned int m68k_read_disassembler_8  (unsigned int address);
@@ -362,7 +362,7 @@ void m68k_pulse_halt(void);
 
 
 /* Trigger a bus error exception */
-void m68k_pulse_bus_error(void);
+void m68k_pulse_bus_error(struct m68ki_cpu_core *state);
 
 
 /* Context switching to allow multiple CPUs */

--- a/m68k.h
+++ b/m68k.h
@@ -52,6 +52,7 @@ extern "C" {
 #include MUSASHI_CNF
 #else
 #include "m68kconf.h"
+
 #endif
 
 /* ======================================================================== */
@@ -93,6 +94,7 @@ extern "C" {
  */
 #define M68K_INT_ACK_SPURIOUS      0xfffffffe
 
+struct m68ki_cpu_core;
 
 /* CPU types for use in m68k_set_cpu_type() */
 enum
@@ -327,10 +329,10 @@ void m68k_init(void);
  *       the CPU for the first time, the CPU will be set to
  *       M68K_CPU_TYPE_68000.
  */
-void m68k_pulse_reset(void);
+void m68k_pulse_reset(struct m68ki_cpu_core *state);
 
 /* execute num_cycles worth of instructions.  returns number of cycles used */
-int m68k_execute(int num_cycles);
+int m68k_execute(struct m68ki_cpu_core *state, int num_cycles);
 
 /* These functions let you read/write/modify the number of cycles left to run
  * while m68k_execute() is running.

--- a/m68k.h
+++ b/m68k.h
@@ -316,7 +316,7 @@ void m68k_set_instr_hook_callback(void  (*callback)(unsigned int pc));
  * Currently supported types are: M68K_CPU_TYPE_68000, M68K_CPU_TYPE_68010,
  * M68K_CPU_TYPE_EC020, and M68K_CPU_TYPE_68020.
  */
-void m68k_set_cpu_type(unsigned int cpu_type);
+void m68k_set_cpu_type(struct m68ki_cpu_core *state, unsigned int cpu_type);
 
 /* Do whatever initialisations the core requires.  Should be called
  * at least once at init time.

--- a/m68k.h
+++ b/m68k.h
@@ -387,7 +387,7 @@ void m68k_state_register(const char *type, int index);
 unsigned int m68k_get_reg(void* context, m68k_register_t reg);
 
 /* Poke values into the internals of the currently running CPU context */
-void m68k_set_reg(m68k_register_t reg, unsigned int value);
+void m68k_set_reg(void *context, m68k_register_t regnum, unsigned int value);
 
 /* Check if an instruction is valid for the specified CPU type */
 unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cpu_type);

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -283,10 +283,10 @@ M68KMAKE_OPCODE_HANDLER_HEADER
 
 #include <stdio.h>
 #include "m68kcpu.h"
-extern void m68040_fpu_op0(void);
-extern void m68040_fpu_op1(void);
-extern void m68851_mmu_ops();
-extern void m68881_ftrap();
+extern void m68040_fpu_op0(m68ki_cpu_core *state);
+extern void m68040_fpu_op1(m68ki_cpu_core *state);
+extern void m68851_mmu_ops(m68ki_cpu_core *state);
+extern void m68881_ftrap(m68ki_cpu_core *state);
 
 /* ======================================================================== */
 /* ========================= INSTRUCTION HANDLERS ========================= */
@@ -923,7 +923,7 @@ M68KMAKE_OP(040fpu0, 32, ., .)
 //	printf("FPU 040fpu0 HAS_FPU=%d\n",!!HAS_FPU);
 	if(HAS_FPU)
 	{
-		m68040_fpu_op0();
+		void m68040_fpu_op0(m68ki_cpu_core *state);
 		return;
 	}
 	m68ki_exception_1111();
@@ -935,7 +935,7 @@ M68KMAKE_OP(040fpu1, 32, ., .)
 //	printf("FPU 040fpu1 HAS_FPU=%d\n",!!HAS_FPU);
 	if(HAS_FPU)
 	{
-		m68040_fpu_op1();
+		void m68040_fpu_op1(m68ki_cpu_core *state);
 		return;
 	}
 	m68ki_exception_1111();
@@ -972,7 +972,7 @@ M68KMAKE_OP(abcd, 8, rr, .)
 
 M68KMAKE_OP(abcd, 8, mm, ax7)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
@@ -999,7 +999,7 @@ M68KMAKE_OP(abcd, 8, mm, ax7)
 
 M68KMAKE_OP(abcd, 8, mm, ay7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
@@ -1026,7 +1026,7 @@ M68KMAKE_OP(abcd, 8, mm, ay7)
 
 M68KMAKE_OP(abcd, 8, mm, axy7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
@@ -1053,7 +1053,7 @@ M68KMAKE_OP(abcd, 8, mm, axy7)
 
 M68KMAKE_OP(abcd, 8, mm, .)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
@@ -1307,7 +1307,7 @@ M68KMAKE_OP(adda, 32, ., .)
 M68KMAKE_OP(addi, 8, ., d)
 {
 	uint* r_dst = &DY;
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint dst = MASK_OUT_ABOVE_8(*r_dst);
 	uint res = src + dst;
 
@@ -1322,7 +1322,7 @@ M68KMAKE_OP(addi, 8, ., d)
 
 M68KMAKE_OP(addi, 8, ., .)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint dst = m68ki_read_8(ea);
 	uint res = src + dst;
@@ -1339,7 +1339,7 @@ M68KMAKE_OP(addi, 8, ., .)
 M68KMAKE_OP(addi, 16, ., d)
 {
 	uint* r_dst = &DY;
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint dst = MASK_OUT_ABOVE_16(*r_dst);
 	uint res = src + dst;
 
@@ -1354,7 +1354,7 @@ M68KMAKE_OP(addi, 16, ., d)
 
 M68KMAKE_OP(addi, 16, ., .)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint dst = m68ki_read_16(ea);
 	uint res = src + dst;
@@ -1371,7 +1371,7 @@ M68KMAKE_OP(addi, 16, ., .)
 M68KMAKE_OP(addi, 32, ., d)
 {
 	uint* r_dst = &DY;
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint dst = *r_dst;
 	uint res = src + dst;
 
@@ -1386,7 +1386,7 @@ M68KMAKE_OP(addi, 32, ., d)
 
 M68KMAKE_OP(addi, 32, ., .)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint dst = m68ki_read_32(ea);
 	uint res = src + dst;
@@ -1569,7 +1569,7 @@ M68KMAKE_OP(addx, 32, rr, .)
 
 M68KMAKE_OP(addx, 8, mm, ax7)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = src + dst + XFLAG_AS_1();
@@ -1587,7 +1587,7 @@ M68KMAKE_OP(addx, 8, mm, ax7)
 
 M68KMAKE_OP(addx, 8, mm, ay7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = src + dst + XFLAG_AS_1();
@@ -1605,7 +1605,7 @@ M68KMAKE_OP(addx, 8, mm, ay7)
 
 M68KMAKE_OP(addx, 8, mm, axy7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = src + dst + XFLAG_AS_1();
@@ -1623,7 +1623,7 @@ M68KMAKE_OP(addx, 8, mm, axy7)
 
 M68KMAKE_OP(addx, 8, mm, .)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = src + dst + XFLAG_AS_1();
@@ -1641,7 +1641,7 @@ M68KMAKE_OP(addx, 8, mm, .)
 
 M68KMAKE_OP(addx, 16, mm, .)
 {
-	uint src = OPER_AY_PD_16();
+	uint src = OPER_AY_PD_16(state);
 	uint ea  = EA_AX_PD_16();
 	uint dst = m68ki_read_16(ea);
 	uint res = src + dst + XFLAG_AS_1();
@@ -1659,7 +1659,7 @@ M68KMAKE_OP(addx, 16, mm, .)
 
 M68KMAKE_OP(addx, 32, mm, .)
 {
-	uint src = OPER_AY_PD_32();
+	uint src = OPER_AY_PD_32(state);
 	uint ea  = EA_AX_PD_32();
 	uint dst = m68ki_read_32(ea);
 	uint res = src + dst + XFLAG_AS_1();
@@ -1779,7 +1779,7 @@ M68KMAKE_OP(and, 32, re, .)
 
 M68KMAKE_OP(andi, 8, ., d)
 {
-	FLAG_Z = MASK_OUT_ABOVE_8(DY &= (OPER_I_8() | 0xffffff00));
+	FLAG_Z = MASK_OUT_ABOVE_8(DY &= (OPER_I_8(state) | 0xffffff00));
 
 	FLAG_N = NFLAG_8(FLAG_Z);
 	FLAG_C = CFLAG_CLEAR;
@@ -1789,7 +1789,7 @@ M68KMAKE_OP(andi, 8, ., d)
 
 M68KMAKE_OP(andi, 8, ., .)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint res = src & m68ki_read_8(ea);
 
@@ -1804,7 +1804,7 @@ M68KMAKE_OP(andi, 8, ., .)
 
 M68KMAKE_OP(andi, 16, ., d)
 {
-	FLAG_Z = MASK_OUT_ABOVE_16(DY &= (OPER_I_16() | 0xffff0000));
+	FLAG_Z = MASK_OUT_ABOVE_16(DY &= (OPER_I_16(state) | 0xffff0000));
 
 	FLAG_N = NFLAG_16(FLAG_Z);
 	FLAG_C = CFLAG_CLEAR;
@@ -1814,7 +1814,7 @@ M68KMAKE_OP(andi, 16, ., d)
 
 M68KMAKE_OP(andi, 16, ., .)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint res = src & m68ki_read_16(ea);
 
@@ -1829,7 +1829,7 @@ M68KMAKE_OP(andi, 16, ., .)
 
 M68KMAKE_OP(andi, 32, ., d)
 {
-	FLAG_Z = DY &= (OPER_I_32());
+	FLAG_Z = DY &= (OPER_I_32(state));
 
 	FLAG_N = NFLAG_32(FLAG_Z);
 	FLAG_C = CFLAG_CLEAR;
@@ -1839,7 +1839,7 @@ M68KMAKE_OP(andi, 32, ., d)
 
 M68KMAKE_OP(andi, 32, ., .)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint res = src & m68ki_read_32(ea);
 
@@ -1854,7 +1854,7 @@ M68KMAKE_OP(andi, 32, ., .)
 
 M68KMAKE_OP(andi, 16, toc, .)
 {
-	m68ki_set_ccr(m68ki_get_ccr() & OPER_I_8());
+	m68ki_set_ccr(m68ki_get_ccr() & OPER_I_8(state));
 }
 
 
@@ -1862,9 +1862,9 @@ M68KMAKE_OP(andi, 16, tos, .)
 {
 	if(FLAG_S)
 	{
-		uint src = OPER_I_16();
+		uint src = OPER_I_16(state);
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_set_sr(m68ki_get_sr() & src);
+		m68ki_set_sr(state, m68ki_get_sr() & src);
 		return;
 	}
 	m68ki_exception_privilege_violation();
@@ -2314,7 +2314,7 @@ M68KMAKE_OP(bcc, 16, ., .)
 {
 	if(M68KMAKE_CC)
 	{
-		uint offset = OPER_I_16();
+		uint offset = OPER_I_16(state);
 		REG_PC -= 2;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		m68ki_branch_16(offset);
@@ -2331,7 +2331,7 @@ M68KMAKE_OP(bcc, 32, ., .)
 	{
 		if(M68KMAKE_CC)
 		{
-			uint offset = OPER_I_32();
+			uint offset = OPER_I_32(state);
 			REG_PC -= 4;
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 			m68ki_branch_32(offset);
@@ -2377,7 +2377,7 @@ M68KMAKE_OP(bchg, 8, r, .)
 M68KMAKE_OP(bchg, 32, s, d)
 {
 	uint* r_dst = &DY;
-	uint mask = 1 << (OPER_I_8() & 0x1f);
+	uint mask = 1 << (OPER_I_8(state) & 0x1f);
 
 	FLAG_Z = *r_dst & mask;
 	*r_dst ^= mask;
@@ -2386,7 +2386,7 @@ M68KMAKE_OP(bchg, 32, s, d)
 
 M68KMAKE_OP(bchg, 8, s, .)
 {
-	uint mask = 1 << (OPER_I_8() & 7);
+	uint mask = 1 << (OPER_I_8(state) & 7);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint src = m68ki_read_8(ea);
 
@@ -2419,7 +2419,7 @@ M68KMAKE_OP(bclr, 8, r, .)
 M68KMAKE_OP(bclr, 32, s, d)
 {
 	uint* r_dst = &DY;
-	uint mask = 1 << (OPER_I_8() & 0x1f);
+	uint mask = 1 << (OPER_I_8(state) & 0x1f);
 
 	FLAG_Z = *r_dst & mask;
 	*r_dst &= ~mask;
@@ -2428,7 +2428,7 @@ M68KMAKE_OP(bclr, 32, s, d)
 
 M68KMAKE_OP(bclr, 8, s, .)
 {
-	uint mask = 1 << (OPER_I_8() & 7);
+	uint mask = 1 << (OPER_I_8(state) & 7);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint src = m68ki_read_8(ea);
 
@@ -2441,7 +2441,7 @@ M68KMAKE_OP(bfchg, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint* data = &DY;
@@ -2476,7 +2476,7 @@ M68KMAKE_OP(bfchg, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint mask_base;
@@ -2530,7 +2530,7 @@ M68KMAKE_OP(bfclr, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint* data = &DY;
@@ -2567,7 +2567,7 @@ M68KMAKE_OP(bfclr, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint mask_base;
@@ -2621,7 +2621,7 @@ M68KMAKE_OP(bfexts, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint64 data = DY;
@@ -2655,7 +2655,7 @@ M68KMAKE_OP(bfexts, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint data;
@@ -2706,7 +2706,7 @@ M68KMAKE_OP(bfextu, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint64 data = DY;
@@ -2740,7 +2740,7 @@ M68KMAKE_OP(bfextu, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint data;
@@ -2790,7 +2790,7 @@ M68KMAKE_OP(bfffo, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint64 data = DY;
@@ -2828,7 +2828,7 @@ M68KMAKE_OP(bfffo, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		sint local_offset;
 		uint width = word2;
@@ -2880,7 +2880,7 @@ M68KMAKE_OP(bfins, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint* data = &DY;
@@ -2922,7 +2922,7 @@ M68KMAKE_OP(bfins, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint insert_base = REG_D[(word2>>12)&7];
@@ -2992,7 +2992,7 @@ M68KMAKE_OP(bfset, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint* data = &DY;
@@ -3029,7 +3029,7 @@ M68KMAKE_OP(bfset, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint mask_base;
@@ -3084,7 +3084,7 @@ M68KMAKE_OP(bftst, 32, ., d)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint offset = (word2>>6)&31;
 		uint width = word2;
 		uint* data = &DY;
@@ -3119,7 +3119,7 @@ M68KMAKE_OP(bftst, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint offset = (word2>>6)&31;
 		uint width = word2;
 		uint mask_base;
@@ -3189,7 +3189,7 @@ M68KMAKE_OP(bra, 8, ., .)
 
 M68KMAKE_OP(bra, 16, ., .)
 {
-	uint offset = OPER_I_16();
+	uint offset = OPER_I_16(state);
 	REG_PC -= 2;
 	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 	m68ki_branch_16(offset);
@@ -3203,7 +3203,7 @@ M68KMAKE_OP(bra, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint offset = OPER_I_32();
+		uint offset = OPER_I_32(state);
 		REG_PC -= 4;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		m68ki_branch_32(offset);
@@ -3248,7 +3248,7 @@ M68KMAKE_OP(bset, 8, r, .)
 M68KMAKE_OP(bset, 32, s, d)
 {
 	uint* r_dst = &DY;
-	uint mask = 1 << (OPER_I_8() & 0x1f);
+	uint mask = 1 << (OPER_I_8(state) & 0x1f);
 
 	FLAG_Z = *r_dst & mask;
 	*r_dst |= mask;
@@ -3257,7 +3257,7 @@ M68KMAKE_OP(bset, 32, s, d)
 
 M68KMAKE_OP(bset, 8, s, .)
 {
-	uint mask = 1 << (OPER_I_8() & 7);
+	uint mask = 1 << (OPER_I_8(state) & 7);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint src = m68ki_read_8(ea);
 
@@ -3276,7 +3276,7 @@ M68KMAKE_OP(bsr, 8, ., .)
 
 M68KMAKE_OP(bsr, 16, ., .)
 {
-	uint offset = OPER_I_16();
+	uint offset = OPER_I_16(state);
 	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 	m68ki_push_32(REG_PC);
 	REG_PC -= 2;
@@ -3288,7 +3288,7 @@ M68KMAKE_OP(bsr, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint offset = OPER_I_32();
+		uint offset = OPER_I_32(state);
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		m68ki_push_32(REG_PC);
 		REG_PC -= 4;
@@ -3320,13 +3320,13 @@ M68KMAKE_OP(btst, 8, r, .)
 
 M68KMAKE_OP(btst, 32, s, d)
 {
-	FLAG_Z = DY & (1 << (OPER_I_8() & 0x1f));
+	FLAG_Z = DY & (1 << (OPER_I_8(state) & 0x1f));
 }
 
 
 M68KMAKE_OP(btst, 8, s, .)
 {
-	uint bit = OPER_I_8() & 7;
+	uint bit = OPER_I_8(state) & 7;
 
 	FLAG_Z = M68KMAKE_GET_OPER_AY_8 & (1 << bit);
 }
@@ -3355,7 +3355,7 @@ M68KMAKE_OP(cas, 8, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint ea = M68KMAKE_GET_EA_AY_8;
 		uint dest = m68ki_read_8(ea);
 		uint* compare = &REG_D[word2 & 7];
@@ -3384,7 +3384,7 @@ M68KMAKE_OP(cas, 16, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint ea = M68KMAKE_GET_EA_AY_16;
 		uint dest = m68ki_read_16(ea);
 		uint* compare = &REG_D[word2 & 7];
@@ -3413,7 +3413,7 @@ M68KMAKE_OP(cas, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint ea = M68KMAKE_GET_EA_AY_32;
 		uint dest = m68ki_read_32(ea);
 		uint* compare = &REG_D[word2 & 7];
@@ -3442,7 +3442,7 @@ M68KMAKE_OP(cas2, 16, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_32();
+		uint word2 = OPER_I_32(state);
 		uint* compare1 = &REG_D[(word2 >> 16) & 7];
 		uint ea1 = REG_DA[(word2 >> 28) & 15];
 		uint dest1 = m68ki_read_16(ea1);
@@ -3487,7 +3487,7 @@ M68KMAKE_OP(cas2, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_32();
+		uint word2 = OPER_I_32(state);
 		uint* compare1 = &REG_D[(word2 >> 16) & 7];
 		uint ea1 = REG_DA[(word2 >> 28) & 15];
 		uint dest1 = m68ki_read_32(ea1);
@@ -3614,7 +3614,7 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint compare = REG_DA[(word2 >> 12) & 15];
 		if(!BIT_F(word2))
 			compare &= 0xff;
@@ -3640,7 +3640,7 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcdi)
 		return;
 	}
 
-      
+
 	m68ki_exception_illegal();
 }
 
@@ -3649,7 +3649,7 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint compare = REG_DA[(word2 >> 12) & 15];
 		if(!BIT_F(word2))
 			compare &= 0xff;
@@ -3682,7 +3682,7 @@ M68KMAKE_OP(chk2cmp2, 8, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint compare = REG_DA[(word2 >> 12) & 15];
 		if(!BIT_F(word2))
 			compare &= 0xff;
@@ -3715,7 +3715,7 @@ M68KMAKE_OP(chk2cmp2, 16, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint compare = REG_DA[(word2 >> 12) & 15];
 		if(!BIT_F(word2))
 			compare &= 0xffff;
@@ -3748,7 +3748,7 @@ M68KMAKE_OP(chk2cmp2, 16, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint compare = REG_DA[(word2 >> 12) & 15];
 		if(!BIT_F(word2))
 			compare &= 0xffff;
@@ -3781,7 +3781,7 @@ M68KMAKE_OP(chk2cmp2, 16, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		sint compare = REG_DA[(word2 >> 12) & 15];
 		if(!BIT_F(word2))
 			compare &= 0xffff;
@@ -3814,7 +3814,7 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint32 word2 = OPER_I_16();
+		uint32 word2 = OPER_I_16(state);
 		sint64 compare = REG_DA[(word2 >> 12) & 15];
 		uint32 ea = EA_PCDI_32();
 		sint64 lower_bound = m68ki_read_pcrel_32(ea);
@@ -3842,7 +3842,7 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint32 word2 = OPER_I_16();
+		uint32 word2 = OPER_I_16(state);
 		sint64 compare = REG_DA[(word2 >> 12) & 15];
 		uint32 ea = EA_PCIX_32();
 		sint64 lower_bound = m68ki_read_32(ea);
@@ -3869,8 +3869,8 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcix)
 M68KMAKE_OP(chk2cmp2, 32, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
-	{   
-		uint32 word2 = OPER_I_16();
+	{
+		uint32 word2 = OPER_I_16(state);
 		sint64 compare = REG_DA[(word2 >> 12) & 15];
 		uint32 ea = M68KMAKE_GET_EA_AY_32;
 		sint64 lower_bound = m68ki_read_32(ea);
@@ -4156,7 +4156,7 @@ M68KMAKE_OP(cmpa, 32, ., .)
 
 M68KMAKE_OP(cmpi, 8, ., d)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint dst = MASK_OUT_ABOVE_8(DY);
 	uint res = dst - src;
 
@@ -4169,7 +4169,7 @@ M68KMAKE_OP(cmpi, 8, ., d)
 
 M68KMAKE_OP(cmpi, 8, ., .)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint dst = M68KMAKE_GET_OPER_AY_8;
 	uint res = dst - src;
 
@@ -4184,8 +4184,8 @@ M68KMAKE_OP(cmpi, 8, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_I_8();
-		uint dst = OPER_PCDI_8();
+		uint src = OPER_I_8(state);
+		uint dst = OPER_PCDI_8(state);
 		uint res = dst - src;
 
 		FLAG_N = NFLAG_8(res);
@@ -4202,8 +4202,8 @@ M68KMAKE_OP(cmpi, 8, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_I_8();
-		uint dst = OPER_PCIX_8();
+		uint src = OPER_I_8(state);
+		uint dst = OPER_PCIX_8(state);
 		uint res = dst - src;
 
 		FLAG_N = NFLAG_8(res);
@@ -4218,7 +4218,7 @@ M68KMAKE_OP(cmpi, 8, ., pcix)
 
 M68KMAKE_OP(cmpi, 16, ., d)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint dst = MASK_OUT_ABOVE_16(DY);
 	uint res = dst - src;
 
@@ -4231,7 +4231,7 @@ M68KMAKE_OP(cmpi, 16, ., d)
 
 M68KMAKE_OP(cmpi, 16, ., .)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint dst = M68KMAKE_GET_OPER_AY_16;
 	uint res = dst - src;
 
@@ -4246,8 +4246,8 @@ M68KMAKE_OP(cmpi, 16, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_I_16();
-		uint dst = OPER_PCDI_16();
+		uint src = OPER_I_16(state);
+		uint dst = OPER_PCDI_16(state);
 		uint res = dst - src;
 
 		FLAG_N = NFLAG_16(res);
@@ -4264,8 +4264,8 @@ M68KMAKE_OP(cmpi, 16, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_I_16();
-		uint dst = OPER_PCIX_16();
+		uint src = OPER_I_16(state);
+		uint dst = OPER_PCIX_16(state);
 		uint res = dst - src;
 
 		FLAG_N = NFLAG_16(res);
@@ -4280,7 +4280,7 @@ M68KMAKE_OP(cmpi, 16, ., pcix)
 
 M68KMAKE_OP(cmpi, 32, ., d)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint dst = DY;
 	uint res = dst - src;
 
@@ -4294,7 +4294,7 @@ M68KMAKE_OP(cmpi, 32, ., d)
 
 M68KMAKE_OP(cmpi, 32, ., .)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint dst = M68KMAKE_GET_OPER_AY_32;
 	uint res = dst - src;
 
@@ -4309,8 +4309,8 @@ M68KMAKE_OP(cmpi, 32, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_I_32();
-		uint dst = OPER_PCDI_32();
+		uint src = OPER_I_32(state);
+		uint dst = OPER_PCDI_32(state);
 		uint res = dst - src;
 
 		FLAG_N = NFLAG_32(res);
@@ -4327,8 +4327,8 @@ M68KMAKE_OP(cmpi, 32, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_I_32();
-		uint dst = OPER_PCIX_32();
+		uint src = OPER_I_32(state);
+		uint dst = OPER_PCIX_32(state);
 		uint res = dst - src;
 
 		FLAG_N = NFLAG_32(res);
@@ -4343,8 +4343,8 @@ M68KMAKE_OP(cmpi, 32, ., pcix)
 
 M68KMAKE_OP(cmpm, 8, ., ax7)
 {
-	uint src = OPER_AY_PI_8();
-	uint dst = OPER_A7_PI_8();
+	uint src = OPER_AY_PI_8(state);
+	uint dst = OPER_A7_PI_8(state);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -4356,8 +4356,8 @@ M68KMAKE_OP(cmpm, 8, ., ax7)
 
 M68KMAKE_OP(cmpm, 8, ., ay7)
 {
-	uint src = OPER_A7_PI_8();
-	uint dst = OPER_AX_PI_8();
+	uint src = OPER_A7_PI_8(state);
+	uint dst = OPER_AX_PI_8(state);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -4369,8 +4369,8 @@ M68KMAKE_OP(cmpm, 8, ., ay7)
 
 M68KMAKE_OP(cmpm, 8, ., axy7)
 {
-	uint src = OPER_A7_PI_8();
-	uint dst = OPER_A7_PI_8();
+	uint src = OPER_A7_PI_8(state);
+	uint dst = OPER_A7_PI_8(state);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -4382,8 +4382,8 @@ M68KMAKE_OP(cmpm, 8, ., axy7)
 
 M68KMAKE_OP(cmpm, 8, ., .)
 {
-	uint src = OPER_AY_PI_8();
-	uint dst = OPER_AX_PI_8();
+	uint src = OPER_AY_PI_8(state);
+	uint dst = OPER_AX_PI_8(state);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -4395,8 +4395,8 @@ M68KMAKE_OP(cmpm, 8, ., .)
 
 M68KMAKE_OP(cmpm, 16, ., .)
 {
-	uint src = OPER_AY_PI_16();
-	uint dst = OPER_AX_PI_16();
+	uint src = OPER_AY_PI_16(state);
+	uint dst = OPER_AX_PI_16(state);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_16(res);
@@ -4408,8 +4408,8 @@ M68KMAKE_OP(cmpm, 16, ., .)
 
 M68KMAKE_OP(cmpm, 32, ., .)
 {
-	uint src = OPER_AY_PI_32();
-	uint dst = OPER_AX_PI_32();
+	uint src = OPER_AY_PI_32(state);
+	uint dst = OPER_AX_PI_32(state);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_32(res);
@@ -4481,7 +4481,7 @@ M68KMAKE_OP(cptrapcc, 32, ., .)
 					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
         // JFF: unsupported, but at least if the trap doesn't occur, app should still work, so at least PC increase is correct
-        REG_PC += 4;  
+        REG_PC += 4;
 		return;
 	}
 	m68ki_exception_1111();
@@ -4491,7 +4491,7 @@ M68KMAKE_OP(ftrapcc,32, ., .)
 {
 	if(HAS_FPU)
 	{
-		m68881_ftrap();
+		m68881_ftrap(state);
 	} else {
 		m68ki_exception_1111();
 	}
@@ -4511,7 +4511,7 @@ M68KMAKE_OP(dbf, 16, ., .)
 	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
 	if(res != 0xffff)
 	{
-		uint offset = OPER_I_16();
+		uint offset = OPER_I_16(state);
 		REG_PC -= 2;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		m68ki_branch_16(offset);
@@ -4533,7 +4533,7 @@ M68KMAKE_OP(dbcc, 16, ., .)
 		*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
 		if(res != 0xffff)
 		{
-			uint offset = OPER_I_16();
+			uint offset = OPER_I_16(state);
 			REG_PC -= 2;
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 			m68ki_branch_16(offset);
@@ -4680,7 +4680,7 @@ M68KMAKE_OP(divl, 32, ., d)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint64 divisor   = DY;
 		uint64 dividend  = 0;
 		uint64 quotient  = 0;
@@ -4748,7 +4748,7 @@ M68KMAKE_OP(divl, 32, ., d)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint divisor = DY;
 		uint dividend_hi = REG_D[word2 & 7];
 		uint dividend_lo = REG_D[(word2 >> 12) & 7];
@@ -4891,7 +4891,7 @@ M68KMAKE_OP(divl, 32, ., .)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint64 divisor = M68KMAKE_GET_OPER_AY_32;
 		uint64 dividend  = 0;
 		uint64 quotient  = 0;
@@ -4959,7 +4959,7 @@ M68KMAKE_OP(divl, 32, ., .)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint divisor = M68KMAKE_GET_OPER_AY_32;
 		uint dividend_hi = REG_D[word2 & 7];
 		uint dividend_lo = REG_D[(word2 >> 12) & 7];
@@ -5173,7 +5173,7 @@ M68KMAKE_OP(eor, 32, ., .)
 
 M68KMAKE_OP(eori, 8, ., d)
 {
-	uint res = MASK_OUT_ABOVE_8(DY ^= OPER_I_8());
+	uint res = MASK_OUT_ABOVE_8(DY ^= OPER_I_8(state));
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5184,7 +5184,7 @@ M68KMAKE_OP(eori, 8, ., d)
 
 M68KMAKE_OP(eori, 8, ., .)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint res = src ^ m68ki_read_8(ea);
 
@@ -5199,7 +5199,7 @@ M68KMAKE_OP(eori, 8, ., .)
 
 M68KMAKE_OP(eori, 16, ., d)
 {
-	uint res = MASK_OUT_ABOVE_16(DY ^= OPER_I_16());
+	uint res = MASK_OUT_ABOVE_16(DY ^= OPER_I_16(state));
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -5210,7 +5210,7 @@ M68KMAKE_OP(eori, 16, ., d)
 
 M68KMAKE_OP(eori, 16, ., .)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint res = src ^ m68ki_read_16(ea);
 
@@ -5225,7 +5225,7 @@ M68KMAKE_OP(eori, 16, ., .)
 
 M68KMAKE_OP(eori, 32, ., d)
 {
-	uint res = DY ^= OPER_I_32();
+	uint res = DY ^= OPER_I_32(state);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -5236,7 +5236,7 @@ M68KMAKE_OP(eori, 32, ., d)
 
 M68KMAKE_OP(eori, 32, ., .)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint res = src ^ m68ki_read_32(ea);
 
@@ -5251,7 +5251,7 @@ M68KMAKE_OP(eori, 32, ., .)
 
 M68KMAKE_OP(eori, 16, toc, .)
 {
-	m68ki_set_ccr(m68ki_get_ccr() ^ OPER_I_8());
+	m68ki_set_ccr(m68ki_get_ccr() ^ OPER_I_8(state));
 }
 
 
@@ -5259,9 +5259,9 @@ M68KMAKE_OP(eori, 16, tos, .)
 {
 	if(FLAG_S)
 	{
-		uint src = OPER_I_16();
+		uint src = OPER_I_16(state);
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_set_sr(m68ki_get_sr() ^ src);
+		m68ki_set_sr(state, m68ki_get_sr() ^ src);
 		return;
 	}
 	m68ki_exception_privilege_violation();
@@ -5373,7 +5373,7 @@ M68KMAKE_OP(link, 16, ., a7)
 {
 	REG_A[7] -= 4;
 	m68ki_write_32(REG_A[7], REG_A[7]);
-	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16()));
+	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
 }
 
 
@@ -5383,7 +5383,7 @@ M68KMAKE_OP(link, 16, ., .)
 
 	m68ki_push_32(*r_dst);
 	*r_dst = REG_A[7];
-	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16()));
+	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
 }
 
 
@@ -5393,7 +5393,7 @@ M68KMAKE_OP(link, 32, ., a7)
 	{
 		REG_A[7] -= 4;
 		m68ki_write_32(REG_A[7], REG_A[7]);
-		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32());
+		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32(state));
 		return;
 	}
 	m68ki_exception_illegal();
@@ -5408,7 +5408,7 @@ M68KMAKE_OP(link, 32, ., .)
 
 		m68ki_push_32(*r_dst);
 		*r_dst = REG_A[7];
-		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32());
+		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32(state));
 		return;
 	}
 	m68ki_exception_illegal();
@@ -6831,7 +6831,7 @@ M68KMAKE_OP(move, 16, tos, d)
 {
 	if(FLAG_S)
 	{
-		m68ki_set_sr(DY);
+		m68ki_set_sr(state, DY);
 		return;
 	}
 	m68ki_exception_privilege_violation();
@@ -6844,7 +6844,7 @@ M68KMAKE_OP(move, 16, tos, .)
 	{
 		uint new_sr = M68KMAKE_GET_OPER_AY_16;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_set_sr(new_sr);
+		m68ki_set_sr(state, new_sr);
 		return;
 	}
 	m68ki_exception_privilege_violation();
@@ -6880,7 +6880,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 	{
 		if(FLAG_S)
 		{
-			uint word2 = OPER_I_16();
+			uint word2 = OPER_I_16(state);
 
 			m68ki_trace_t0();		   /* auto-disable (see m68kcpu.h) */
 			switch (word2 & 0xfff)
@@ -7010,7 +7010,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 	{
 		if(FLAG_S)
 		{
-			uint word2 = OPER_I_16();
+			uint word2 = OPER_I_16(state);
 
 			m68ki_trace_t0();		   /* auto-disable (see m68kcpu.h) */
 			switch (word2 & 0xfff)
@@ -7175,7 +7175,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 M68KMAKE_OP(movem, 16, re, pd)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = AY;
 	uint count = 0;
 
@@ -7195,7 +7195,7 @@ M68KMAKE_OP(movem, 16, re, pd)
 M68KMAKE_OP(movem, 16, re, .)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint count = 0;
 
@@ -7214,7 +7214,7 @@ M68KMAKE_OP(movem, 16, re, .)
 M68KMAKE_OP(movem, 32, re, pd)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = AY;
 	uint count = 0;
 
@@ -7235,7 +7235,7 @@ M68KMAKE_OP(movem, 32, re, pd)
 M68KMAKE_OP(movem, 32, re, .)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint count = 0;
 
@@ -7254,7 +7254,7 @@ M68KMAKE_OP(movem, 32, re, .)
 M68KMAKE_OP(movem, 16, er, pi)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = AY;
 	uint count = 0;
 
@@ -7274,7 +7274,7 @@ M68KMAKE_OP(movem, 16, er, pi)
 M68KMAKE_OP(movem, 16, er, pcdi)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = EA_PCDI_16();
 	uint count = 0;
 
@@ -7293,7 +7293,7 @@ M68KMAKE_OP(movem, 16, er, pcdi)
 M68KMAKE_OP(movem, 16, er, pcix)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = EA_PCIX_16();
 	uint count = 0;
 
@@ -7312,7 +7312,7 @@ M68KMAKE_OP(movem, 16, er, pcix)
 M68KMAKE_OP(movem, 16, er, .)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint count = 0;
 
@@ -7331,7 +7331,7 @@ M68KMAKE_OP(movem, 16, er, .)
 M68KMAKE_OP(movem, 32, er, pi)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = AY;
 	uint count = 0;
 
@@ -7351,7 +7351,7 @@ M68KMAKE_OP(movem, 32, er, pi)
 M68KMAKE_OP(movem, 32, er, pcdi)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = EA_PCDI_32();
 	uint count = 0;
 
@@ -7370,7 +7370,7 @@ M68KMAKE_OP(movem, 32, er, pcdi)
 M68KMAKE_OP(movem, 32, er, pcix)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = EA_PCIX_32();
 	uint count = 0;
 
@@ -7389,7 +7389,7 @@ M68KMAKE_OP(movem, 32, er, pcix)
 M68KMAKE_OP(movem, 32, er, .)
 {
 	uint i = 0;
-	uint register_list = OPER_I_16();
+	uint register_list = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint count = 0;
 
@@ -7451,7 +7451,7 @@ M68KMAKE_OP(moves, 8, ., .)
 	{
 		if(FLAG_S)
 		{
-			uint word2 = OPER_I_16();
+			uint word2 = OPER_I_16(state);
 			uint ea = M68KMAKE_GET_EA_AY_8;
 
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
@@ -7486,7 +7486,7 @@ M68KMAKE_OP(moves, 16, ., .)
 	{
 		if(FLAG_S)
 		{
-			uint word2 = OPER_I_16();
+			uint word2 = OPER_I_16(state);
 			uint ea = M68KMAKE_GET_EA_AY_16;
 
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
@@ -7521,7 +7521,7 @@ M68KMAKE_OP(moves, 32, ., .)
 	{
 		if(FLAG_S)
 		{
-			uint word2 = OPER_I_16();
+			uint word2 = OPER_I_16(state);
 			uint ea = M68KMAKE_GET_EA_AY_32;
 
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
@@ -7558,7 +7558,7 @@ M68KMAKE_OP(moveq, 32, ., .)
 
 M68KMAKE_OP(move16, 32, ., .)
 {
-	uint16 w2 = OPER_I_16();
+	uint16 w2 = OPER_I_16(state);
 	int ax = REG_IR & 7;
 	int ay = (w2 >> 12) & 7;
 
@@ -7634,7 +7634,7 @@ M68KMAKE_OP(mull, 32, ., d)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint64 src = DY;
 		uint64 dst = REG_D[(word2 >> 12) & 7];
 		uint64 res;
@@ -7682,7 +7682,7 @@ M68KMAKE_OP(mull, 32, ., d)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint src = DY;
 		uint dst = REG_D[(word2 >> 12) & 7];
 		uint neg = GET_MSB_32(src ^ dst);
@@ -7758,7 +7758,7 @@ M68KMAKE_OP(mull, 32, ., .)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint64 src = M68KMAKE_GET_OPER_AY_32;
 		uint64 dst = REG_D[(word2 >> 12) & 7];
 		uint64 res;
@@ -7806,7 +7806,7 @@ M68KMAKE_OP(mull, 32, ., .)
 
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint word2 = OPER_I_16();
+		uint word2 = OPER_I_16(state);
 		uint src = M68KMAKE_GET_OPER_AY_32;
 		uint dst = REG_D[(word2 >> 12) & 7];
 		uint neg = GET_MSB_32(src ^ dst);
@@ -8326,7 +8326,7 @@ M68KMAKE_OP(or, 32, re, .)
 
 M68KMAKE_OP(ori, 8, ., d)
 {
-	uint res = MASK_OUT_ABOVE_8((DY |= OPER_I_8()));
+	uint res = MASK_OUT_ABOVE_8((DY |= OPER_I_8(state)));
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -8337,7 +8337,7 @@ M68KMAKE_OP(ori, 8, ., d)
 
 M68KMAKE_OP(ori, 8, ., .)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint res = MASK_OUT_ABOVE_8(src | m68ki_read_8(ea));
 
@@ -8352,7 +8352,7 @@ M68KMAKE_OP(ori, 8, ., .)
 
 M68KMAKE_OP(ori, 16, ., d)
 {
-	uint res = MASK_OUT_ABOVE_16(DY |= OPER_I_16());
+	uint res = MASK_OUT_ABOVE_16(DY |= OPER_I_16(state));
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -8363,7 +8363,7 @@ M68KMAKE_OP(ori, 16, ., d)
 
 M68KMAKE_OP(ori, 16, ., .)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint res = MASK_OUT_ABOVE_16(src | m68ki_read_16(ea));
 
@@ -8378,7 +8378,7 @@ M68KMAKE_OP(ori, 16, ., .)
 
 M68KMAKE_OP(ori, 32, ., d)
 {
-	uint res = DY |= OPER_I_32();
+	uint res = DY |= OPER_I_32(state);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -8389,7 +8389,7 @@ M68KMAKE_OP(ori, 32, ., d)
 
 M68KMAKE_OP(ori, 32, ., .)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint res = src | m68ki_read_32(ea);
 
@@ -8404,7 +8404,7 @@ M68KMAKE_OP(ori, 32, ., .)
 
 M68KMAKE_OP(ori, 16, toc, .)
 {
-	m68ki_set_ccr(m68ki_get_ccr() | OPER_I_8());
+	m68ki_set_ccr(m68ki_get_ccr() | OPER_I_8(state));
 }
 
 
@@ -8412,9 +8412,9 @@ M68KMAKE_OP(ori, 16, tos, .)
 {
 	if(FLAG_S)
 	{
-		uint src = OPER_I_16();
+		uint src = OPER_I_16(state);
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_set_sr(m68ki_get_sr() | src);
+		m68ki_set_sr(state, m68ki_get_sr() | src);
 		return;
 	}
 	m68ki_exception_privilege_violation();
@@ -8426,7 +8426,7 @@ M68KMAKE_OP(pack, 16, rr, .)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		/* Note: DX and DY are reversed in Motorola's docs */
-		uint src = DY + OPER_I_16();
+		uint src = DY + OPER_I_16(state);
 		uint* r_dst = &DX;
 
 		*r_dst = MASK_OUT_BELOW_8(*r_dst) | ((src >> 4) & 0x00f0) | (src & 0x000f);
@@ -8444,7 +8444,7 @@ M68KMAKE_OP(pack, 16, mm, ax7)
 		uint ea_src = EA_AY_PD_8();
 		uint src = m68ki_read_8(ea_src);
 		ea_src = EA_AY_PD_8();
-		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16(state);
 
 		m68ki_write_8(EA_A7_PD_8(), ((src >> 8) & 0x000f) | ((src<<4) & 0x00f0));
 		return;
@@ -8461,7 +8461,7 @@ M68KMAKE_OP(pack, 16, mm, ay7)
 		uint ea_src = EA_A7_PD_8();
 		uint src = m68ki_read_8(ea_src);
 		ea_src = EA_A7_PD_8();
-		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16();
+		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16(state);
 
 		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
@@ -8477,7 +8477,7 @@ M68KMAKE_OP(pack, 16, mm, axy7)
 		uint ea_src = EA_A7_PD_8();
 		uint src = m68ki_read_8(ea_src);
 		ea_src = EA_A7_PD_8();
-		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16();
+		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16(state);
 
 		m68ki_write_8(EA_A7_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
@@ -8494,7 +8494,7 @@ M68KMAKE_OP(pack, 16, mm, .)
 		uint ea_src = EA_AY_PD_8();
 		uint src = m68ki_read_8(ea_src);
 		ea_src = EA_AY_PD_8();
-		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16();
+		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16(state);
 
 		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
@@ -8534,7 +8534,7 @@ M68KMAKE_OP(pmmu, 32, ., .)
 {
 	if ((CPU_TYPE_IS_EC020_PLUS(CPU_TYPE)) && (HAS_PMMU))
 	{
-		m68851_mmu_ops();
+		void m68851_mmu_ops(m68ki_cpu_core *state);
 	}
 	else
 	{
@@ -9335,7 +9335,7 @@ M68KMAKE_OP(rtd, 32, ., .)
 		uint new_pc = m68ki_pull_32();
 
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16()));
+		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
 		m68ki_jump(new_pc);
 		return;
 	}
@@ -9359,7 +9359,7 @@ M68KMAKE_OP(rte, 32, ., .)
 			new_sr = m68ki_pull_16();
 			new_pc = m68ki_pull_32();
 			m68ki_jump(new_pc);
-			m68ki_set_sr(new_sr);
+			m68ki_set_sr(state, new_sr);
 
 			CPU_INSTR_MODE = INSTRUCTION_YES;
 			CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9376,7 +9376,7 @@ M68KMAKE_OP(rte, 32, ., .)
 				new_pc = m68ki_pull_32();
 				m68ki_fake_pull_16();	/* format word */
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
@@ -9386,7 +9386,7 @@ M68KMAKE_OP(rte, 32, ., .)
 				new_pc = m68ki_pull_32();
 				m68ki_fake_pull_16();	/* format word */
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				m68ki_fake_pull_16();  /* special status */
@@ -9421,7 +9421,7 @@ rte_loop:
 				new_pc = m68ki_pull_32();
 				m68ki_fake_pull_16();	/* format word */
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
@@ -9429,7 +9429,7 @@ rte_loop:
 				new_sr = m68ki_pull_16();
 				m68ki_fake_pull_32();	/* program counter */
 				m68ki_fake_pull_16();	/* format word */
-				m68ki_set_sr_noint(new_sr);
+				m68ki_set_sr_noint(state, new_sr);
 				goto rte_loop;
 			case 2: /* Trap */
 				new_sr = m68ki_pull_16();
@@ -9437,7 +9437,7 @@ rte_loop:
 				m68ki_fake_pull_16();	/* format word */
 				m68ki_fake_pull_32();	/* address */
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
@@ -9461,7 +9461,7 @@ rte_loop:
 				m68ki_fake_pull_32();   /* $34: pd2 */
 				m68ki_fake_pull_32();   /* $38: pd3 */
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
@@ -9480,7 +9480,7 @@ rte_loop:
 				m68ki_fake_pull_32();   /* $1c: internal registers */
 
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
@@ -9515,7 +9515,7 @@ rte_loop:
 				m68ki_fake_pull_32();   /* $58:  */
 
 				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
+				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
@@ -9591,7 +9591,7 @@ M68KMAKE_OP(sbcd, 8, rr, .)
 
 M68KMAKE_OP(sbcd, 8, mm, ax7)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
@@ -9621,7 +9621,7 @@ M68KMAKE_OP(sbcd, 8, mm, ax7)
 
 M68KMAKE_OP(sbcd, 8, mm, ay7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
@@ -9651,7 +9651,7 @@ M68KMAKE_OP(sbcd, 8, mm, ay7)
 
 M68KMAKE_OP(sbcd, 8, mm, axy7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
@@ -9681,7 +9681,7 @@ M68KMAKE_OP(sbcd, 8, mm, axy7)
 
 M68KMAKE_OP(sbcd, 8, mm, .)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
@@ -9755,10 +9755,10 @@ M68KMAKE_OP(stop, 0, ., .)
 {
 	if(FLAG_S)
 	{
-		uint new_sr = OPER_I_16();
+		uint new_sr = OPER_I_16(state);
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		CPU_STOPPED |= STOP_LEVEL_STOP;
-		m68ki_set_sr(new_sr);
+		m68ki_set_sr(state, new_sr);
 		if(m68ki_remaining_cycles >= CYC_INSTRUCTION[REG_IR])
 			m68ki_remaining_cycles = CYC_INSTRUCTION[REG_IR];
 		else
@@ -9998,7 +9998,7 @@ M68KMAKE_OP(suba, 32, ., .)
 M68KMAKE_OP(subi, 8, ., d)
 {
 	uint* r_dst = &DY;
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint dst = MASK_OUT_ABOVE_8(*r_dst);
 	uint res = dst - src;
 
@@ -10013,7 +10013,7 @@ M68KMAKE_OP(subi, 8, ., d)
 
 M68KMAKE_OP(subi, 8, ., .)
 {
-	uint src = OPER_I_8();
+	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint dst = m68ki_read_8(ea);
 	uint res = dst - src;
@@ -10030,7 +10030,7 @@ M68KMAKE_OP(subi, 8, ., .)
 M68KMAKE_OP(subi, 16, ., d)
 {
 	uint* r_dst = &DY;
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint dst = MASK_OUT_ABOVE_16(*r_dst);
 	uint res = dst - src;
 
@@ -10045,7 +10045,7 @@ M68KMAKE_OP(subi, 16, ., d)
 
 M68KMAKE_OP(subi, 16, ., .)
 {
-	uint src = OPER_I_16();
+	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint dst = m68ki_read_16(ea);
 	uint res = dst - src;
@@ -10062,7 +10062,7 @@ M68KMAKE_OP(subi, 16, ., .)
 M68KMAKE_OP(subi, 32, ., d)
 {
 	uint* r_dst = &DY;
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint dst = *r_dst;
 	uint res = dst - src;
 
@@ -10077,7 +10077,7 @@ M68KMAKE_OP(subi, 32, ., d)
 
 M68KMAKE_OP(subi, 32, ., .)
 {
-	uint src = OPER_I_32();
+	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint dst = m68ki_read_32(ea);
 	uint res = dst - src;
@@ -10259,7 +10259,7 @@ M68KMAKE_OP(subx, 32, rr, .)
 
 M68KMAKE_OP(subx, 8, mm, ax7)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = dst - src - XFLAG_AS_1();
@@ -10277,7 +10277,7 @@ M68KMAKE_OP(subx, 8, mm, ax7)
 
 M68KMAKE_OP(subx, 8, mm, ay7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = dst - src - XFLAG_AS_1();
@@ -10295,7 +10295,7 @@ M68KMAKE_OP(subx, 8, mm, ay7)
 
 M68KMAKE_OP(subx, 8, mm, axy7)
 {
-	uint src = OPER_A7_PD_8();
+	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = dst - src - XFLAG_AS_1();
@@ -10313,7 +10313,7 @@ M68KMAKE_OP(subx, 8, mm, axy7)
 
 M68KMAKE_OP(subx, 8, mm, .)
 {
-	uint src = OPER_AY_PD_8();
+	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
 	uint dst = m68ki_read_8(ea);
 	uint res = dst - src - XFLAG_AS_1();
@@ -10331,7 +10331,7 @@ M68KMAKE_OP(subx, 8, mm, .)
 
 M68KMAKE_OP(subx, 16, mm, .)
 {
-	uint src = OPER_AY_PD_16();
+	uint src = OPER_AY_PD_16(state);
 	uint ea  = EA_AX_PD_16();
 	uint dst = m68ki_read_16(ea);
 	uint res = dst - src - XFLAG_AS_1();
@@ -10349,7 +10349,7 @@ M68KMAKE_OP(subx, 16, mm, .)
 
 M68KMAKE_OP(subx, 32, mm, .)
 {
-	uint src = OPER_AY_PD_32();
+	uint src = OPER_AY_PD_32(state);
 	uint ea  = EA_AX_PD_32();
 	uint dst = m68ki_read_32(ea);
 	uint res = dst - src - XFLAG_AS_1();
@@ -10571,7 +10571,7 @@ M68KMAKE_OP(tst, 8, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_PCDI_8();
+		uint res = OPER_PCDI_8(state);
 
 		FLAG_N = NFLAG_8(res);
 		FLAG_Z = res;
@@ -10587,7 +10587,7 @@ M68KMAKE_OP(tst, 8, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_PCIX_8();
+		uint res = OPER_PCIX_8(state);
 
 		FLAG_N = NFLAG_8(res);
 		FLAG_Z = res;
@@ -10603,7 +10603,7 @@ M68KMAKE_OP(tst, 8, ., i)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_I_8();
+		uint res = OPER_I_8(state);
 
 		FLAG_N = NFLAG_8(res);
 		FLAG_Z = res;
@@ -10657,7 +10657,7 @@ M68KMAKE_OP(tst, 16, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_PCDI_16();
+		uint res = OPER_PCDI_16(state);
 
 		FLAG_N = NFLAG_16(res);
 		FLAG_Z = res;
@@ -10673,7 +10673,7 @@ M68KMAKE_OP(tst, 16, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_PCIX_16();
+		uint res = OPER_PCIX_16(state);
 
 		FLAG_N = NFLAG_16(res);
 		FLAG_Z = res;
@@ -10689,7 +10689,7 @@ M68KMAKE_OP(tst, 16, ., i)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_I_16();
+		uint res = OPER_I_16(state);
 
 		FLAG_N = NFLAG_16(res);
 		FLAG_Z = res;
@@ -10743,7 +10743,7 @@ M68KMAKE_OP(tst, 32, ., pcdi)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_PCDI_32();
+		uint res = OPER_PCDI_32(state);
 
 		FLAG_N = NFLAG_32(res);
 		FLAG_Z = res;
@@ -10759,7 +10759,7 @@ M68KMAKE_OP(tst, 32, ., pcix)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_PCIX_32();
+		uint res = OPER_PCIX_32(state);
 
 		FLAG_N = NFLAG_32(res);
 		FLAG_Z = res;
@@ -10775,7 +10775,7 @@ M68KMAKE_OP(tst, 32, ., i)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint res = OPER_I_32();
+		uint res = OPER_I_32(state);
 
 		FLAG_N = NFLAG_32(res);
 		FLAG_Z = res;
@@ -10810,7 +10810,7 @@ M68KMAKE_OP(unpk, 16, rr, .)
 		uint src = DY;
 		uint* r_dst = &DX;
 
-		*r_dst = MASK_OUT_BELOW_16(*r_dst) | (((((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16()) & 0xffff);
+		*r_dst = MASK_OUT_BELOW_16(*r_dst) | (((((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state)) & 0xffff);
 		return;
 	}
 	m68ki_exception_illegal();
@@ -10822,10 +10822,10 @@ M68KMAKE_OP(unpk, 16, mm, ax7)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		/* Note: AX and AY are reversed in Motorola's docs */
-		uint src = OPER_AY_PD_8();
+		uint src = OPER_AY_PD_8(state);
 		uint ea_dst;
 
-		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_A7_PD_8();
 		m68ki_write_8(ea_dst, src & 0xff);
 		ea_dst = EA_A7_PD_8();
@@ -10841,10 +10841,10 @@ M68KMAKE_OP(unpk, 16, mm, ay7)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		/* Note: AX and AY are reversed in Motorola's docs */
-		uint src = OPER_A7_PD_8();
+		uint src = OPER_A7_PD_8(state);
 		uint ea_dst;
 
-		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_AX_PD_8();
 		m68ki_write_8(ea_dst, src & 0xff);
 		ea_dst = EA_AX_PD_8();
@@ -10859,10 +10859,10 @@ M68KMAKE_OP(unpk, 16, mm, axy7)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		uint src = OPER_A7_PD_8();
+		uint src = OPER_A7_PD_8(state);
 		uint ea_dst;
 
-		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_A7_PD_8();
 		m68ki_write_8(ea_dst, src & 0xff);
 		ea_dst = EA_A7_PD_8();
@@ -10878,10 +10878,10 @@ M68KMAKE_OP(unpk, 16, mm, .)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		/* Note: AX and AY are reversed in Motorola's docs */
-		uint src = OPER_AY_PD_8();
+		uint src = OPER_AY_PD_8(state);
 		uint ea_dst;
 
-		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_AX_PD_8();
 		m68ki_write_8(ea_dst, src & 0xff);
 		ea_dst = EA_AX_PD_8();

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -908,13 +908,13 @@ M68KMAKE_OPCODE_HANDLER_BODY
 
 M68KMAKE_OP(1010, 0, ., .)
 {
-	m68ki_exception_1010();
+	m68ki_exception_1010(state);
 }
 
 
 M68KMAKE_OP(1111, 0, ., .)
 {
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -923,10 +923,10 @@ M68KMAKE_OP(040fpu0, 32, ., .)
 //	printf("FPU 040fpu0 HAS_FPU=%d\n",!!HAS_FPU);
 	if(HAS_FPU)
 	{
-		void m68040_fpu_op0(m68ki_cpu_core *state);
+		m68040_fpu_op0(state);
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -935,10 +935,10 @@ M68KMAKE_OP(040fpu1, 32, ., .)
 //	printf("FPU 040fpu1 HAS_FPU=%d\n",!!HAS_FPU);
 	if(HAS_FPU)
 	{
-		void m68040_fpu_op1(m68ki_cpu_core *state);
+		m68040_fpu_op1(state);
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -974,7 +974,7 @@ M68KMAKE_OP(abcd, 8, mm, ax7)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
 	uint corf = 0;
 
@@ -993,7 +993,7 @@ M68KMAKE_OP(abcd, 8, mm, ax7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1001,7 +1001,7 @@ M68KMAKE_OP(abcd, 8, mm, ay7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
 	uint corf = 0;
 
@@ -1020,7 +1020,7 @@ M68KMAKE_OP(abcd, 8, mm, ay7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1028,7 +1028,7 @@ M68KMAKE_OP(abcd, 8, mm, axy7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
 	uint corf = 0;
 
@@ -1047,7 +1047,7 @@ M68KMAKE_OP(abcd, 8, mm, axy7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1055,7 +1055,7 @@ M68KMAKE_OP(abcd, 8, mm, .)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
 	uint corf = 0;
 
@@ -1074,7 +1074,7 @@ M68KMAKE_OP(abcd, 8, mm, .)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1210,7 +1210,7 @@ M68KMAKE_OP(add, 8, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint src = MASK_OUT_ABOVE_8(DX);
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_8(res);
@@ -1218,7 +1218,7 @@ M68KMAKE_OP(add, 8, re, .)
 	FLAG_X = FLAG_C = CFLAG_8(res);
 	FLAG_Z = MASK_OUT_ABOVE_8(res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -1226,7 +1226,7 @@ M68KMAKE_OP(add, 16, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint src = MASK_OUT_ABOVE_16(DX);
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_16(res);
@@ -1234,7 +1234,7 @@ M68KMAKE_OP(add, 16, re, .)
 	FLAG_X = FLAG_C = CFLAG_16(res);
 	FLAG_Z = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -1242,7 +1242,7 @@ M68KMAKE_OP(add, 32, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint src = DX;
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_32(res);
@@ -1250,7 +1250,7 @@ M68KMAKE_OP(add, 32, re, .)
 	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
 	FLAG_Z = MASK_OUT_ABOVE_32(res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -1324,7 +1324,7 @@ M68KMAKE_OP(addi, 8, ., .)
 {
 	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_8(res);
@@ -1332,7 +1332,7 @@ M68KMAKE_OP(addi, 8, ., .)
 	FLAG_X = FLAG_C = CFLAG_8(res);
 	FLAG_Z = MASK_OUT_ABOVE_8(res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -1356,7 +1356,7 @@ M68KMAKE_OP(addi, 16, ., .)
 {
 	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_16(res);
@@ -1364,7 +1364,7 @@ M68KMAKE_OP(addi, 16, ., .)
 	FLAG_X = FLAG_C = CFLAG_16(res);
 	FLAG_Z = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -1388,7 +1388,7 @@ M68KMAKE_OP(addi, 32, ., .)
 {
 	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_32(res);
@@ -1396,7 +1396,7 @@ M68KMAKE_OP(addi, 32, ., .)
 	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
 	FLAG_Z = MASK_OUT_ABOVE_32(res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -1420,7 +1420,7 @@ M68KMAKE_OP(addq, 8, ., .)
 {
 	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_8(res);
@@ -1428,7 +1428,7 @@ M68KMAKE_OP(addq, 8, ., .)
 	FLAG_X = FLAG_C = CFLAG_8(res);
 	FLAG_Z = MASK_OUT_ABOVE_8(res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -1460,7 +1460,7 @@ M68KMAKE_OP(addq, 16, ., .)
 {
 	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = src + dst;
 
 	FLAG_N = NFLAG_16(res);
@@ -1468,7 +1468,7 @@ M68KMAKE_OP(addq, 16, ., .)
 	FLAG_X = FLAG_C = CFLAG_16(res);
 	FLAG_Z = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -1500,7 +1500,7 @@ M68KMAKE_OP(addq, 32, ., .)
 {
 	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = src + dst;
 
 
@@ -1509,7 +1509,7 @@ M68KMAKE_OP(addq, 32, ., .)
 	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
 	FLAG_Z = MASK_OUT_ABOVE_32(res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -1571,7 +1571,7 @@ M68KMAKE_OP(addx, 8, mm, ax7)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst + XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -1581,7 +1581,7 @@ M68KMAKE_OP(addx, 8, mm, ax7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1589,7 +1589,7 @@ M68KMAKE_OP(addx, 8, mm, ay7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst + XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -1599,7 +1599,7 @@ M68KMAKE_OP(addx, 8, mm, ay7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1607,7 +1607,7 @@ M68KMAKE_OP(addx, 8, mm, axy7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst + XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -1617,7 +1617,7 @@ M68KMAKE_OP(addx, 8, mm, axy7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1625,7 +1625,7 @@ M68KMAKE_OP(addx, 8, mm, .)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = src + dst + XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -1635,7 +1635,7 @@ M68KMAKE_OP(addx, 8, mm, .)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1643,7 +1643,7 @@ M68KMAKE_OP(addx, 16, mm, .)
 {
 	uint src = OPER_AY_PD_16(state);
 	uint ea  = EA_AX_PD_16();
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = src + dst + XFLAG_AS_1();
 
 	FLAG_N = NFLAG_16(res);
@@ -1653,7 +1653,7 @@ M68KMAKE_OP(addx, 16, mm, .)
 	res = MASK_OUT_ABOVE_16(res);
 	FLAG_Z |= res;
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 }
 
 
@@ -1661,7 +1661,7 @@ M68KMAKE_OP(addx, 32, mm, .)
 {
 	uint src = OPER_AY_PD_32(state);
 	uint ea  = EA_AX_PD_32();
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = src + dst + XFLAG_AS_1();
 
 	FLAG_N = NFLAG_32(res);
@@ -1671,7 +1671,7 @@ M68KMAKE_OP(addx, 32, mm, .)
 	res = MASK_OUT_ABOVE_32(res);
 	FLAG_Z |= res;
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 }
 
 
@@ -1738,42 +1738,42 @@ M68KMAKE_OP(and, 32, er, .)
 M68KMAKE_OP(and, 8, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = DX & m68ki_read_8(ea);
+	uint res = DX & m68ki_read_8(state, ea);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_C = CFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
 	FLAG_Z = MASK_OUT_ABOVE_8(res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
 M68KMAKE_OP(and, 16, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = DX & m68ki_read_16(ea);
+	uint res = DX & m68ki_read_16(state, ea);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_C = CFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
 	FLAG_Z = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
 M68KMAKE_OP(and, 32, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = DX & m68ki_read_32(ea);
+	uint res = DX & m68ki_read_32(state, ea);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
 	FLAG_C = CFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 }
 
 
@@ -1791,14 +1791,14 @@ M68KMAKE_OP(andi, 8, ., .)
 {
 	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = src & m68ki_read_8(ea);
+	uint res = src & m68ki_read_8(state, ea);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
 	FLAG_C = CFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -1816,14 +1816,14 @@ M68KMAKE_OP(andi, 16, ., .)
 {
 	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = src & m68ki_read_16(ea);
+	uint res = src & m68ki_read_16(state, ea);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
 	FLAG_C = CFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 }
 
 
@@ -1841,14 +1841,14 @@ M68KMAKE_OP(andi, 32, ., .)
 {
 	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = src & m68ki_read_32(ea);
+	uint res = src & m68ki_read_32(state, ea);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
 	FLAG_C = CFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 }
 
 
@@ -1867,7 +1867,7 @@ M68KMAKE_OP(andi, 16, tos, .)
 		m68ki_set_sr(state, m68ki_get_sr() & src);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -2096,13 +2096,13 @@ M68KMAKE_OP(asr, 32, r, .)
 M68KMAKE_OP(asr, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = src >> 1;
 
 	if(GET_MSB_16(src))
 		res |= 0x8000;
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -2285,10 +2285,10 @@ M68KMAKE_OP(asl, 32, r, .)
 M68KMAKE_OP(asl, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = MASK_OUT_ABOVE_16(src << 1);
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -2366,11 +2366,11 @@ M68KMAKE_OP(bchg, 32, r, d)
 M68KMAKE_OP(bchg, 8, r, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 	uint mask = 1 << (DX & 7);
 
 	FLAG_Z = src & mask;
-	m68ki_write_8(ea, src ^ mask);
+	m68ki_write_8(state, ea, src ^ mask);
 }
 
 
@@ -2388,10 +2388,10 @@ M68KMAKE_OP(bchg, 8, s, .)
 {
 	uint mask = 1 << (OPER_I_8(state) & 7);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 
 	FLAG_Z = src & mask;
-	m68ki_write_8(ea, src ^ mask);
+	m68ki_write_8(state, ea, src ^ mask);
 }
 
 
@@ -2408,11 +2408,11 @@ M68KMAKE_OP(bclr, 32, r, d)
 M68KMAKE_OP(bclr, 8, r, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 	uint mask = 1 << (DX & 7);
 
 	FLAG_Z = src & mask;
-	m68ki_write_8(ea, src & ~mask);
+	m68ki_write_8(state, ea, src & ~mask);
 }
 
 
@@ -2430,10 +2430,10 @@ M68KMAKE_OP(bclr, 8, s, .)
 {
 	uint mask = 1 << (OPER_I_8(state) & 7);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 
 	FLAG_Z = src & mask;
-	m68ki_write_8(ea, src & ~mask);
+	m68ki_write_8(state, ea, src & ~mask);
 }
 
 
@@ -2468,7 +2468,7 @@ M68KMAKE_OP(bfchg, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2505,24 +2505,24 @@ M68KMAKE_OP(bfchg, 32, ., .)
 		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 		mask_long = mask_base >> offset;
 
-		data_long = m68ki_read_32(ea);
+		data_long = m68ki_read_32(state, ea);
 		FLAG_N = NFLAG_32(data_long << offset);
 		FLAG_Z = data_long & mask_long;
 		FLAG_V = VFLAG_CLEAR;
 		FLAG_C = CFLAG_CLEAR;
 
-		m68ki_write_32(ea, data_long ^ mask_long);
+		m68ki_write_32(state, ea, data_long ^ mask_long);
 
 		if((width + offset) > 32)
 		{
 			mask_byte = MASK_OUT_ABOVE_8(mask_base) << (8-offset);
-			data_byte = m68ki_read_8(ea+4);
+			data_byte = m68ki_read_8(state, ea+4);
 			FLAG_Z |= (data_byte & mask_byte);
-			m68ki_write_8(ea+4, data_byte ^ mask_byte);
+			m68ki_write_8(state, ea+4, data_byte ^ mask_byte);
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2559,7 +2559,7 @@ M68KMAKE_OP(bfclr, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2596,24 +2596,24 @@ M68KMAKE_OP(bfclr, 32, ., .)
 		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 		mask_long = mask_base >> offset;
 
-		data_long = m68ki_read_32(ea);
+		data_long = m68ki_read_32(state, ea);
 		FLAG_N = NFLAG_32(data_long << offset);
 		FLAG_Z = data_long & mask_long;
 		FLAG_V = VFLAG_CLEAR;
 		FLAG_C = CFLAG_CLEAR;
 
-		m68ki_write_32(ea, data_long & ~mask_long);
+		m68ki_write_32(state, ea, data_long & ~mask_long);
 
 		if((width + offset) > 32)
 		{
 			mask_byte = MASK_OUT_ABOVE_8(mask_base) << (8-offset);
-			data_byte = m68ki_read_8(ea+4);
+			data_byte = m68ki_read_8(state, ea+4);
 			FLAG_Z |= (data_byte & mask_byte);
-			m68ki_write_8(ea+4, data_byte & ~mask_byte);
+			m68ki_write_8(state, ea+4, data_byte & ~mask_byte);
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2647,7 +2647,7 @@ M68KMAKE_OP(bfexts, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2679,13 +2679,13 @@ M68KMAKE_OP(bfexts, 32, ., .)
 		}
 		width = ((width-1) & 31) + 1;
 
-		data = (offset+width) < 8 ? (m68ki_read_8(ea) << 24) :
-			(offset+width) < 16 ? (m68ki_read_16(ea) << 16) : m68ki_read_32(ea);
+		data = (offset+width) < 8 ? (m68ki_read_8(state, ea) << 24) :
+			(offset+width) < 16 ? (m68ki_read_16(state, ea) << 16) : m68ki_read_32(state, ea);
 
 		data = MASK_OUT_ABOVE_32(data<<offset);
 
 		if((offset+width) > 32)
-			data |= (m68ki_read_8(ea+4) << offset) >> 8;
+			data |= (m68ki_read_8(state, ea+4) << offset) >> 8;
 
 		FLAG_N = NFLAG_32(data);
 		data  = MAKE_INT_32(data) >> (32 - width);
@@ -2698,7 +2698,7 @@ M68KMAKE_OP(bfexts, 32, ., .)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2732,7 +2732,7 @@ M68KMAKE_OP(bfextu, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2764,12 +2764,12 @@ M68KMAKE_OP(bfextu, 32, ., .)
 		}
 		width = ((width-1) & 31) + 1;
 
-	data = (offset+width) < 8 ? (m68ki_read_8(ea) << 24) :
-			(offset+width) < 16 ? (m68ki_read_16(ea) << 16) : m68ki_read_32(ea);
+	data = (offset+width) < 8 ? (m68ki_read_8(state, ea) << 24) :
+			(offset+width) < 16 ? (m68ki_read_16(state, ea) << 16) : m68ki_read_32(state, ea);
 		data = MASK_OUT_ABOVE_32(data<<offset);
 
 		if((offset+width) > 32)
-			data |= (m68ki_read_8(ea+4) << offset) >> 8;
+			data |= (m68ki_read_8(state, ea+4) << offset) >> 8;
 
 		FLAG_N = NFLAG_32(data);
 		data  >>= (32 - width);
@@ -2782,7 +2782,7 @@ M68KMAKE_OP(bfextu, 32, ., .)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2820,7 +2820,7 @@ M68KMAKE_OP(bfffo, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2852,11 +2852,11 @@ M68KMAKE_OP(bfffo, 32, ., .)
 		}
 		width = ((width-1) & 31) + 1;
 
-		data = (offset+width) < 16 ? (m68ki_read_16(ea) << 16) : m68ki_read_32(ea);
+		data = (offset+width) < 16 ? (m68ki_read_16(state, ea) << 16) : m68ki_read_32(state, ea);
 		data = MASK_OUT_ABOVE_32(data<<local_offset);
 
 		if((local_offset+width) > 32)
-			data |= (m68ki_read_8(ea+4) << local_offset) >> 8;
+			data |= (m68ki_read_8(state, ea+4) << local_offset) >> 8;
 
 		FLAG_N = NFLAG_32(data);
 		data  >>= (32 - width);
@@ -2872,7 +2872,7 @@ M68KMAKE_OP(bfffo, 32, ., .)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2914,7 +2914,7 @@ M68KMAKE_OP(bfins, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -2961,30 +2961,30 @@ M68KMAKE_OP(bfins, 32, ., .)
 		FLAG_Z = insert_base;
 		insert_long = insert_base >> offset;
 
-		data_long = (offset+width) < 8 ? (m68ki_read_8(ea) << 24) :
-				(offset+width) < 16 ? (m68ki_read_16(ea) << 16) : m68ki_read_32(ea);
+		data_long = (offset+width) < 8 ? (m68ki_read_8(state, ea) << 24) :
+				(offset+width) < 16 ? (m68ki_read_16(state, ea) << 16) : m68ki_read_32(state, ea);
 		FLAG_V = VFLAG_CLEAR;
 		FLAG_C = CFLAG_CLEAR;
 
 		if((width + offset) < 8) {
-			m68ki_write_8(ea, ((data_long & ~mask_long) | insert_long) >> 24);
+			m68ki_write_8(state, ea, ((data_long & ~mask_long) | insert_long) >> 24);
 		} else if((width + offset) < 16) {
-			m68ki_write_16(ea, ((data_long & ~mask_long) | insert_long) >> 16);
+			m68ki_write_16(state, ea, ((data_long & ~mask_long) | insert_long) >> 16);
 		} else {
-			m68ki_write_32(ea, (data_long & ~mask_long) | insert_long);
+			m68ki_write_32(state, ea, (data_long & ~mask_long) | insert_long);
 		}
 
 		if((width + offset) > 32)
 		{
 			mask_byte = MASK_OUT_ABOVE_8(mask_base);
 			insert_byte = MASK_OUT_ABOVE_8(insert_base);
-			data_byte = m68ki_read_8(ea+4);
+			data_byte = m68ki_read_8(state, ea+4);
 			FLAG_Z |= (data_byte & mask_byte);
-			m68ki_write_8(ea+4, (data_byte & ~mask_byte) | insert_byte);
+			m68ki_write_8(state, ea+4, (data_byte & ~mask_byte) | insert_byte);
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3021,7 +3021,7 @@ M68KMAKE_OP(bfset, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3059,24 +3059,24 @@ M68KMAKE_OP(bfset, 32, ., .)
 		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 		mask_long = mask_base >> offset;
 
-		data_long = m68ki_read_32(ea);
+		data_long = m68ki_read_32(state, ea);
 		FLAG_N = NFLAG_32(data_long << offset);
 		FLAG_Z = data_long & mask_long;
 		FLAG_V = VFLAG_CLEAR;
 		FLAG_C = CFLAG_CLEAR;
 
-		m68ki_write_32(ea, data_long | mask_long);
+		m68ki_write_32(state, ea, data_long | mask_long);
 
 		if((width + offset) > 32)
 		{
 			mask_byte = MASK_OUT_ABOVE_8(mask_base);
-			data_byte = m68ki_read_8(ea+4);
+			data_byte = m68ki_read_8(state, ea+4);
 			FLAG_Z |= (data_byte & mask_byte);
-			m68ki_write_8(ea+4, data_byte | mask_byte);
+			m68ki_write_8(state, ea+4, data_byte | mask_byte);
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3111,7 +3111,7 @@ M68KMAKE_OP(bftst, 32, ., d)
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3148,7 +3148,7 @@ M68KMAKE_OP(bftst, 32, ., .)
 		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
 		mask_long = mask_base >> offset;
 
-		data_long = m68ki_read_32(ea);
+		data_long = m68ki_read_32(state, ea);
 		FLAG_N = ((data_long & (0x80000000 >> offset))<<offset)>>24;
 		FLAG_Z = data_long & mask_long;
 		FLAG_V = VFLAG_CLEAR;
@@ -3157,12 +3157,12 @@ M68KMAKE_OP(bftst, 32, ., .)
 		if((width + offset) > 32)
 		{
 			mask_byte = MASK_OUT_ABOVE_8(mask_base);
-			data_byte = m68ki_read_8(ea+4);
+			data_byte = m68ki_read_8(state, ea+4);
 			FLAG_Z |= (data_byte & mask_byte);
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3173,7 +3173,7 @@ M68KMAKE_OP(bkpt, 0, ., .)
 	{
 		m68ki_bkpt_ack(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE) ? REG_IR & 7 : 0);	/* auto-disable (see m68kcpu.h) */
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3215,7 +3215,7 @@ M68KMAKE_OP(bra, 32, ., .)
 	else
 	{
 // TODO: review this...
-		m68ki_exception_illegal();
+		m68ki_exception_illegal(state);
 //		m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 //		m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
 //		if(REG_PC == REG_PPC)
@@ -3237,11 +3237,11 @@ M68KMAKE_OP(bset, 32, r, d)
 M68KMAKE_OP(bset, 8, r, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 	uint mask = 1 << (DX & 7);
 
 	FLAG_Z = src & mask;
-	m68ki_write_8(ea, src | mask);
+	m68ki_write_8(state, ea, src | mask);
 }
 
 
@@ -3259,17 +3259,17 @@ M68KMAKE_OP(bset, 8, s, .)
 {
 	uint mask = 1 << (OPER_I_8(state) & 7);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 
 	FLAG_Z = src & mask;
-	m68ki_write_8(ea, src | mask);
+	m68ki_write_8(state, ea, src | mask);
 }
 
 
 M68KMAKE_OP(bsr, 8, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_push_32(REG_PC);
+	m68ki_push_32(state, REG_PC);
 	m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
 }
 
@@ -3278,7 +3278,7 @@ M68KMAKE_OP(bsr, 16, ., .)
 {
 	uint offset = OPER_I_16(state);
 	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-	m68ki_push_32(REG_PC);
+	m68ki_push_32(state, REG_PC);
 	REG_PC -= 2;
 	m68ki_branch_16(offset);
 }
@@ -3290,7 +3290,7 @@ M68KMAKE_OP(bsr, 32, ., .)
 	{
 		uint offset = OPER_I_32(state);
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_push_32(REG_PC);
+		m68ki_push_32(state, REG_PC);
 		REG_PC -= 4;
 		m68ki_branch_32(offset);
 		return;
@@ -3298,9 +3298,9 @@ M68KMAKE_OP(bsr, 32, ., .)
 	else
 	{
 // TODO: review this...
-		m68ki_exception_illegal();
+		m68ki_exception_illegal(state);
 //		m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-//		m68ki_push_32(REG_PC);
+//		m68ki_push_32(state, REG_PC);
 //		m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
 	}
 }
@@ -3347,7 +3347,7 @@ M68KMAKE_OP(callm, 32, ., .)
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3357,7 +3357,7 @@ M68KMAKE_OP(cas, 8, ., .)
 	{
 		uint word2 = OPER_I_16(state);
 		uint ea = M68KMAKE_GET_EA_AY_8;
-		uint dest = m68ki_read_8(ea);
+		uint dest = m68ki_read_8(state, ea);
 		uint* compare = &REG_D[word2 & 7];
 		uint res = dest - MASK_OUT_ABOVE_8(*compare);
 
@@ -3372,11 +3372,11 @@ M68KMAKE_OP(cas, 8, ., .)
 		else
 		{
 			USE_CYCLES(3);
-			m68ki_write_8(ea, MASK_OUT_ABOVE_8(REG_D[(word2 >> 6) & 7]));
+			m68ki_write_8(state, ea, MASK_OUT_ABOVE_8(REG_D[(word2 >> 6) & 7]));
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3386,7 +3386,7 @@ M68KMAKE_OP(cas, 16, ., .)
 	{
 		uint word2 = OPER_I_16(state);
 		uint ea = M68KMAKE_GET_EA_AY_16;
-		uint dest = m68ki_read_16(ea);
+		uint dest = m68ki_read_16(state, ea);
 		uint* compare = &REG_D[word2 & 7];
 		uint res = dest - MASK_OUT_ABOVE_16(*compare);
 
@@ -3401,11 +3401,11 @@ M68KMAKE_OP(cas, 16, ., .)
 		else
 		{
 			USE_CYCLES(3);
-			m68ki_write_16(ea, MASK_OUT_ABOVE_16(REG_D[(word2 >> 6) & 7]));
+			m68ki_write_16(state, ea, MASK_OUT_ABOVE_16(REG_D[(word2 >> 6) & 7]));
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3415,7 +3415,7 @@ M68KMAKE_OP(cas, 32, ., .)
 	{
 		uint word2 = OPER_I_16(state);
 		uint ea = M68KMAKE_GET_EA_AY_32;
-		uint dest = m68ki_read_32(ea);
+		uint dest = m68ki_read_32(state, ea);
 		uint* compare = &REG_D[word2 & 7];
 		uint res = dest - *compare;
 
@@ -3430,11 +3430,11 @@ M68KMAKE_OP(cas, 32, ., .)
 		else
 		{
 			USE_CYCLES(3);
-			m68ki_write_32(ea, REG_D[(word2 >> 6) & 7]);
+			m68ki_write_32(state, ea, REG_D[(word2 >> 6) & 7]);
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3445,11 +3445,11 @@ M68KMAKE_OP(cas2, 16, ., .)
 		uint word2 = OPER_I_32(state);
 		uint* compare1 = &REG_D[(word2 >> 16) & 7];
 		uint ea1 = REG_DA[(word2 >> 28) & 15];
-		uint dest1 = m68ki_read_16(ea1);
+		uint dest1 = m68ki_read_16(state, ea1);
 		uint res1 = dest1 - MASK_OUT_ABOVE_16(*compare1);
 		uint* compare2 = &REG_D[word2 & 7];
 		uint ea2 = REG_DA[(word2 >> 12) & 15];
-		uint dest2 = m68ki_read_16(ea2);
+		uint dest2 = m68ki_read_16(state, ea2);
 		uint res2;
 
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
@@ -3470,8 +3470,8 @@ M68KMAKE_OP(cas2, 16, ., .)
 			if(COND_EQ())
 			{
 				USE_CYCLES(3);
-				m68ki_write_16(ea1, REG_D[(word2 >> 22) & 7]);
-				m68ki_write_16(ea2, REG_D[(word2 >> 6) & 7]);
+				m68ki_write_16(state, ea1, REG_D[(word2 >> 22) & 7]);
+				m68ki_write_16(state, ea2, REG_D[(word2 >> 6) & 7]);
 				return;
 			}
 		}
@@ -3479,7 +3479,7 @@ M68KMAKE_OP(cas2, 16, ., .)
 		*compare2 = BIT_F(word2) ? (uint)MAKE_INT_16(dest2) : MASK_OUT_BELOW_16(*compare2) | dest2;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3490,11 +3490,11 @@ M68KMAKE_OP(cas2, 32, ., .)
 		uint word2 = OPER_I_32(state);
 		uint* compare1 = &REG_D[(word2 >> 16) & 7];
 		uint ea1 = REG_DA[(word2 >> 28) & 15];
-		uint dest1 = m68ki_read_32(ea1);
+		uint dest1 = m68ki_read_32(state, ea1);
 		uint res1 = dest1 - *compare1;
 		uint* compare2 = &REG_D[word2 & 7];
 		uint ea2 = REG_DA[(word2 >> 12) & 15];
-		uint dest2 = m68ki_read_32(ea2);
+		uint dest2 = m68ki_read_32(state, ea2);
 		uint res2;
 
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
@@ -3515,8 +3515,8 @@ M68KMAKE_OP(cas2, 32, ., .)
 			if(COND_EQ())
 			{
 				USE_CYCLES(3);
-				m68ki_write_32(ea1, REG_D[(word2 >> 22) & 7]);
-				m68ki_write_32(ea2, REG_D[(word2 >> 6) & 7]);
+				m68ki_write_32(state, ea1, REG_D[(word2 >> 22) & 7]);
+				m68ki_write_32(state, ea2, REG_D[(word2 >> 6) & 7]);
 				return;
 			}
 		}
@@ -3524,7 +3524,7 @@ M68KMAKE_OP(cas2, 32, ., .)
 		*compare2 = dest2;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3542,7 +3542,7 @@ M68KMAKE_OP(chk, 16, ., d)
 		return;
 	}
 	FLAG_N = (src < 0)<<7;
-	m68ki_exception_trap(EXCEPTION_CHK);
+	m68ki_exception_trap(state, EXCEPTION_CHK);
 }
 
 
@@ -3560,7 +3560,7 @@ M68KMAKE_OP(chk, 16, ., .)
 		return;
 	}
 	FLAG_N = (src < 0)<<7;
-	m68ki_exception_trap(EXCEPTION_CHK);
+	m68ki_exception_trap(state, EXCEPTION_CHK);
 }
 
 
@@ -3580,10 +3580,10 @@ M68KMAKE_OP(chk, 32, ., d)
 			return;
 		}
 		FLAG_N = (src < 0)<<7;
-		m68ki_exception_trap(EXCEPTION_CHK);
+		m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3603,10 +3603,10 @@ M68KMAKE_OP(chk, 32, ., .)
 			return;
 		}
 		FLAG_N = (src < 0)<<7;
-		m68ki_exception_trap(EXCEPTION_CHK);
+		m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3620,8 +3620,8 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcdi)
 			compare &= 0xff;
 
 		uint ea = EA_PCDI_8();
-		sint lower_bound = m68ki_read_pcrel_8(ea);
-		sint upper_bound = m68ki_read_pcrel_8(ea + 1);
+		sint lower_bound = m68ki_read_pcrel_8(state, ea);
+		sint upper_bound = m68ki_read_pcrel_8(state, ea + 1);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x80) {
@@ -3636,12 +3636,12 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcdi)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
 
 
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3655,8 +3655,8 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcix)
 			compare &= 0xff;
 
 		uint ea = EA_PCIX_8();
-		sint lower_bound = m68ki_read_pcrel_8(ea);
-		sint upper_bound = m68ki_read_pcrel_8(ea + 1);
+		sint lower_bound = m68ki_read_pcrel_8(state, ea);
+		sint upper_bound = m68ki_read_pcrel_8(state, ea + 1);
 
 		if (lower_bound & 0x80) {
 			lower_bound = (int32)(int8)lower_bound;
@@ -3670,11 +3670,11 @@ M68KMAKE_OP(chk2cmp2, 8, ., pcix)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3688,8 +3688,8 @@ M68KMAKE_OP(chk2cmp2, 8, ., .)
 			compare &= 0xff;
 
 		uint ea = M68KMAKE_GET_EA_AY_8;
-		sint lower_bound = (int8)m68ki_read_8(ea);
-		sint upper_bound = (int8)m68ki_read_8(ea + 1);
+		sint lower_bound = (int8)m68ki_read_8(state, ea);
+		sint upper_bound = (int8)m68ki_read_8(state, ea + 1);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x80) {
@@ -3704,10 +3704,10 @@ M68KMAKE_OP(chk2cmp2, 8, ., .)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3721,8 +3721,8 @@ M68KMAKE_OP(chk2cmp2, 16, ., pcdi)
 			compare &= 0xffff;
 
 		uint ea = EA_PCDI_16();
-		sint lower_bound = (int16)m68ki_read_pcrel_16(ea);
-		sint upper_bound = (int16)m68ki_read_pcrel_16(ea + 2);
+		sint lower_bound = (int16)m68ki_read_pcrel_16(state, ea);
+		sint upper_bound = (int16)m68ki_read_pcrel_16(state, ea + 2);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x8000) {
@@ -3737,10 +3737,10 @@ M68KMAKE_OP(chk2cmp2, 16, ., pcdi)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3754,8 +3754,8 @@ M68KMAKE_OP(chk2cmp2, 16, ., pcix)
 			compare &= 0xffff;
 
 		uint ea = EA_PCIX_16();
-		sint lower_bound = (int16)m68ki_read_pcrel_16(ea);
-		sint upper_bound = (int16)m68ki_read_pcrel_16(ea + 2);
+		sint lower_bound = (int16)m68ki_read_pcrel_16(state, ea);
+		sint upper_bound = (int16)m68ki_read_pcrel_16(state, ea + 2);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x8000) {
@@ -3770,10 +3770,10 @@ M68KMAKE_OP(chk2cmp2, 16, ., pcix)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3787,8 +3787,8 @@ M68KMAKE_OP(chk2cmp2, 16, ., .)
 			compare &= 0xffff;
 
 		uint ea = M68KMAKE_GET_EA_AY_16;
-		sint lower_bound = (int16)m68ki_read_16(ea);
-		sint upper_bound = (int16)m68ki_read_16(ea + 2);
+		sint lower_bound = (int16)m68ki_read_16(state, ea);
+		sint upper_bound = (int16)m68ki_read_16(state, ea + 2);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x8000) {
@@ -3803,10 +3803,10 @@ M68KMAKE_OP(chk2cmp2, 16, ., .)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3817,8 +3817,8 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcdi)
 		uint32 word2 = OPER_I_16(state);
 		sint64 compare = REG_DA[(word2 >> 12) & 15];
 		uint32 ea = EA_PCDI_32();
-		sint64 lower_bound = m68ki_read_pcrel_32(ea);
-		sint64 upper_bound = m68ki_read_pcrel_32(ea + 4);
+		sint64 lower_bound = m68ki_read_pcrel_32(state, ea);
+		sint64 upper_bound = m68ki_read_pcrel_32(state, ea + 4);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x80000000) {
@@ -3831,10 +3831,10 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcdi)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3845,8 +3845,8 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcix)
 		uint32 word2 = OPER_I_16(state);
 		sint64 compare = REG_DA[(word2 >> 12) & 15];
 		uint32 ea = EA_PCIX_32();
-		sint64 lower_bound = m68ki_read_32(ea);
-		sint64 upper_bound = m68ki_read_32(ea + 4);
+		sint64 lower_bound = m68ki_read_32(state, ea);
+		sint64 upper_bound = m68ki_read_32(state, ea + 4);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x80000000) {
@@ -3859,10 +3859,10 @@ M68KMAKE_OP(chk2cmp2, 32, ., pcix)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3873,8 +3873,8 @@ M68KMAKE_OP(chk2cmp2, 32, ., .)
 		uint32 word2 = OPER_I_16(state);
 		sint64 compare = REG_DA[(word2 >> 12) & 15];
 		uint32 ea = M68KMAKE_GET_EA_AY_32;
-		sint64 lower_bound = m68ki_read_32(ea);
-		sint64 upper_bound = m68ki_read_32(ea + 4);
+		sint64 lower_bound = m68ki_read_32(state, ea);
+		sint64 upper_bound = m68ki_read_32(state, ea + 4);
 
 		// for signed compare, the arithmetically smaller value is the lower bound
 		if (lower_bound & 0x80000000) {
@@ -3887,10 +3887,10 @@ M68KMAKE_OP(chk2cmp2, 32, ., .)
 		FLAG_Z = ((upper_bound == compare) || (lower_bound == compare)) ? 0 : 1;
 
 		if(COND_CS() && BIT_B(word2))
-				m68ki_exception_trap(EXCEPTION_CHK);
+				m68ki_exception_trap(state, EXCEPTION_CHK);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -3910,8 +3910,8 @@ M68KMAKE_OP(clr, 8, ., .)
 	uint32 ea = M68KMAKE_GET_EA_AY_8;
 
 	if(CPU_TYPE_IS_000(CPU_TYPE))
-		m68ki_read_8(ea);   /* the 68000 does a dummy read, the value is discarded */
-	m68ki_write_8(ea, 0);
+		m68ki_read_8(state, ea);   /* the 68000 does a dummy read, the value is discarded */
+	m68ki_write_8(state, ea, 0);
 
 	FLAG_N = NFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
@@ -3936,8 +3936,8 @@ M68KMAKE_OP(clr, 16, ., .)
 	uint32 ea = M68KMAKE_GET_EA_AY_16;
 
 	if(CPU_TYPE_IS_000(CPU_TYPE))
-		m68ki_read_16(ea);  /* the 68000 does a dummy read, the value is discarded */
-	m68ki_write_16(ea, 0);
+		m68ki_read_16(state, ea);  /* the 68000 does a dummy read, the value is discarded */
+	m68ki_write_16(state, ea, 0);
 
 	FLAG_N = NFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
@@ -3962,8 +3962,8 @@ M68KMAKE_OP(clr, 32, ., .)
 	uint32 ea = M68KMAKE_GET_EA_AY_32;
 
 	if(CPU_TYPE_IS_000(CPU_TYPE))
-		m68ki_read_32(ea);  /* the 68000 does a dummy read, the value is discarded */
-	m68ki_write_32(ea, 0);
+		m68ki_read_32(state, ea);  /* the 68000 does a dummy read, the value is discarded */
+	m68ki_write_32(state, ea, 0);
 
 	FLAG_N = NFLAG_CLEAR;
 	FLAG_V = VFLAG_CLEAR;
@@ -4194,7 +4194,7 @@ M68KMAKE_OP(cmpi, 8, ., pcdi)
 		FLAG_C = CFLAG_8(res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -4212,7 +4212,7 @@ M68KMAKE_OP(cmpi, 8, ., pcix)
 		FLAG_C = CFLAG_8(res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -4256,7 +4256,7 @@ M68KMAKE_OP(cmpi, 16, ., pcdi)
 		FLAG_C = CFLAG_16(res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -4274,7 +4274,7 @@ M68KMAKE_OP(cmpi, 16, ., pcix)
 		FLAG_C = CFLAG_16(res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -4319,7 +4319,7 @@ M68KMAKE_OP(cmpi, 32, ., pcdi)
 		FLAG_C = CFLAG_SUB_32(src, dst, res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -4337,7 +4337,7 @@ M68KMAKE_OP(cmpi, 32, ., pcix)
 		FLAG_C = CFLAG_SUB_32(src, dst, res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -4428,7 +4428,7 @@ M68KMAKE_OP(cpbcc, 32, ., .)
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -4441,7 +4441,7 @@ M68KMAKE_OP(cpdbcc, 32, ., .)
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -4456,7 +4456,7 @@ M68KMAKE_OP(cpgen, 32, ., .)
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -4469,7 +4469,7 @@ M68KMAKE_OP(cpscc, 32, ., .)
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 
@@ -4484,7 +4484,7 @@ M68KMAKE_OP(cptrapcc, 32, ., .)
         REG_PC += 4;
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 M68KMAKE_OP(ftrapcc,32, ., .)
@@ -4493,7 +4493,7 @@ M68KMAKE_OP(ftrapcc,32, ., .)
 	{
 		m68881_ftrap(state);
 	} else {
-		m68ki_exception_1111();
+		m68ki_exception_1111(state);
 	}
 }
 
@@ -4581,7 +4581,7 @@ M68KMAKE_OP(divs, 16, ., d)
 		FLAG_V = VFLAG_SET;
 		return;
 	}
-	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+	m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 }
 
 
@@ -4618,7 +4618,7 @@ M68KMAKE_OP(divs, 16, ., .)
 		FLAG_V = VFLAG_SET;
 		return;
 	}
-	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+	m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 }
 
 
@@ -4644,7 +4644,7 @@ M68KMAKE_OP(divu, 16, ., d)
 		FLAG_V = VFLAG_SET;
 		return;
 	}
-	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+	m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 }
 
 
@@ -4670,7 +4670,7 @@ M68KMAKE_OP(divu, 16, ., .)
 		FLAG_V = VFLAG_SET;
 		return;
 	}
-	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+	m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 }
 
 
@@ -4739,10 +4739,10 @@ M68KMAKE_OP(divl, 32, ., d)
 			FLAG_C = CFLAG_CLEAR;
 			return;
 		}
-		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #else
 
@@ -4876,10 +4876,10 @@ M68KMAKE_OP(divl, 32, ., d)
 			FLAG_C = CFLAG_CLEAR;
 			return;
 		}
-		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #endif
 }
@@ -4950,10 +4950,10 @@ M68KMAKE_OP(divl, 32, ., .)
 			FLAG_C = CFLAG_CLEAR;
 			return;
 		}
-		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #else
 
@@ -5087,10 +5087,10 @@ M68KMAKE_OP(divl, 32, ., .)
 			FLAG_C = CFLAG_CLEAR;
 			return;
 		}
-		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		m68ki_exception_trap(state, EXCEPTION_ZERO_DIVIDE);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #endif
 }
@@ -5110,9 +5110,9 @@ M68KMAKE_OP(eor, 8, ., d)
 M68KMAKE_OP(eor, 8, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = MASK_OUT_ABOVE_8(DX ^ m68ki_read_8(ea));
+	uint res = MASK_OUT_ABOVE_8(DX ^ m68ki_read_8(state, ea));
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5135,9 +5135,9 @@ M68KMAKE_OP(eor, 16, ., d)
 M68KMAKE_OP(eor, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = MASK_OUT_ABOVE_16(DX ^ m68ki_read_16(ea));
+	uint res = MASK_OUT_ABOVE_16(DX ^ m68ki_read_16(state, ea));
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -5160,9 +5160,9 @@ M68KMAKE_OP(eor, 32, ., d)
 M68KMAKE_OP(eor, 32, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = DX ^ m68ki_read_32(ea);
+	uint res = DX ^ m68ki_read_32(state, ea);
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -5186,9 +5186,9 @@ M68KMAKE_OP(eori, 8, ., .)
 {
 	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = src ^ m68ki_read_8(ea);
+	uint res = src ^ m68ki_read_8(state, ea);
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5212,9 +5212,9 @@ M68KMAKE_OP(eori, 16, ., .)
 {
 	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = src ^ m68ki_read_16(ea);
+	uint res = src ^ m68ki_read_16(state, ea);
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -5238,9 +5238,9 @@ M68KMAKE_OP(eori, 32, ., .)
 {
 	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = src ^ m68ki_read_32(ea);
+	uint res = src ^ m68ki_read_32(state, ea);
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -5264,7 +5264,7 @@ M68KMAKE_OP(eori, 16, tos, .)
 		m68ki_set_sr(state, m68ki_get_sr() ^ src);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -5338,13 +5338,13 @@ M68KMAKE_OP(extb, 32, ., .)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
 M68KMAKE_OP(illegal, 0, ., .)
 {
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 M68KMAKE_OP(jmp, 32, ., .)
@@ -5358,7 +5358,7 @@ M68KMAKE_OP(jsr, 32, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_push_32(REG_PC);
+	m68ki_push_32(state, REG_PC);
 	m68ki_jump(ea);
 }
 
@@ -5372,7 +5372,7 @@ M68KMAKE_OP(lea, 32, ., .)
 M68KMAKE_OP(link, 16, ., a7)
 {
 	REG_A[7] -= 4;
-	m68ki_write_32(REG_A[7], REG_A[7]);
+	m68ki_write_32(state, REG_A[7], REG_A[7]);
 	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
 }
 
@@ -5381,7 +5381,7 @@ M68KMAKE_OP(link, 16, ., .)
 {
 	uint* r_dst = &AY;
 
-	m68ki_push_32(*r_dst);
+	m68ki_push_32(state, *r_dst);
 	*r_dst = REG_A[7];
 	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
 }
@@ -5392,11 +5392,11 @@ M68KMAKE_OP(link, 32, ., a7)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		REG_A[7] -= 4;
-		m68ki_write_32(REG_A[7], REG_A[7]);
+		m68ki_write_32(state, REG_A[7], REG_A[7]);
 		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32(state));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -5406,12 +5406,12 @@ M68KMAKE_OP(link, 32, ., .)
 	{
 		uint* r_dst = &AY;
 
-		m68ki_push_32(*r_dst);
+		m68ki_push_32(state, *r_dst);
 		*r_dst = REG_A[7];
 		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32(state));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -5585,10 +5585,10 @@ M68KMAKE_OP(lsr, 32, r, .)
 M68KMAKE_OP(lsr, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = src >> 1;
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_CLEAR;
 	FLAG_Z = res;
@@ -5767,10 +5767,10 @@ M68KMAKE_OP(lsl, 32, r, .)
 M68KMAKE_OP(lsl, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = MASK_OUT_ABOVE_16(src << 1);
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -5812,7 +5812,7 @@ M68KMAKE_OP(move, 8, ai, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AX_AI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5826,7 +5826,7 @@ M68KMAKE_OP(move, 8, ai, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AX_AI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5840,7 +5840,7 @@ M68KMAKE_OP(move, 8, pi7, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_A7_PI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5854,7 +5854,7 @@ M68KMAKE_OP(move, 8, pi, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AX_PI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5868,7 +5868,7 @@ M68KMAKE_OP(move, 8, pi7, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_A7_PI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5882,7 +5882,7 @@ M68KMAKE_OP(move, 8, pi, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AX_PI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5896,7 +5896,7 @@ M68KMAKE_OP(move, 8, pd7, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_A7_PD_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5910,7 +5910,7 @@ M68KMAKE_OP(move, 8, pd, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AX_PD_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5924,7 +5924,7 @@ M68KMAKE_OP(move, 8, pd7, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_A7_PD_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5938,7 +5938,7 @@ M68KMAKE_OP(move, 8, pd, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AX_PD_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5952,7 +5952,7 @@ M68KMAKE_OP(move, 8, di, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AX_DI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5966,7 +5966,7 @@ M68KMAKE_OP(move, 8, di, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AX_DI_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5980,7 +5980,7 @@ M68KMAKE_OP(move, 8, ix, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AX_IX_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -5994,7 +5994,7 @@ M68KMAKE_OP(move, 8, ix, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AX_IX_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -6008,7 +6008,7 @@ M68KMAKE_OP(move, 8, aw, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AW_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -6022,7 +6022,7 @@ M68KMAKE_OP(move, 8, aw, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AW_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -6036,7 +6036,7 @@ M68KMAKE_OP(move, 8, al, d)
 	uint res = MASK_OUT_ABOVE_8(DY);
 	uint ea = EA_AL_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -6050,7 +6050,7 @@ M68KMAKE_OP(move, 8, al, .)
 	uint res = M68KMAKE_GET_OPER_AY_8;
 	uint ea = EA_AL_8();
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -6106,7 +6106,7 @@ M68KMAKE_OP(move, 16, ai, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AX_AI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6120,7 +6120,7 @@ M68KMAKE_OP(move, 16, ai, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AX_AI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6134,7 +6134,7 @@ M68KMAKE_OP(move, 16, ai, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AX_AI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6148,7 +6148,7 @@ M68KMAKE_OP(move, 16, pi, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AX_PI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6162,7 +6162,7 @@ M68KMAKE_OP(move, 16, pi, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AX_PI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6176,7 +6176,7 @@ M68KMAKE_OP(move, 16, pi, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AX_PI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6190,7 +6190,7 @@ M68KMAKE_OP(move, 16, pd, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AX_PD_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6204,7 +6204,7 @@ M68KMAKE_OP(move, 16, pd, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AX_PD_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6218,7 +6218,7 @@ M68KMAKE_OP(move, 16, pd, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AX_PD_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6232,7 +6232,7 @@ M68KMAKE_OP(move, 16, di, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AX_DI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6246,7 +6246,7 @@ M68KMAKE_OP(move, 16, di, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AX_DI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6260,7 +6260,7 @@ M68KMAKE_OP(move, 16, di, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AX_DI_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6274,7 +6274,7 @@ M68KMAKE_OP(move, 16, ix, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AX_IX_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6288,7 +6288,7 @@ M68KMAKE_OP(move, 16, ix, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AX_IX_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6302,7 +6302,7 @@ M68KMAKE_OP(move, 16, ix, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AX_IX_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6316,7 +6316,7 @@ M68KMAKE_OP(move, 16, aw, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AW_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6330,7 +6330,7 @@ M68KMAKE_OP(move, 16, aw, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AW_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6344,7 +6344,7 @@ M68KMAKE_OP(move, 16, aw, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AW_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6358,7 +6358,7 @@ M68KMAKE_OP(move, 16, al, d)
 	uint res = MASK_OUT_ABOVE_16(DY);
 	uint ea = EA_AL_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6372,7 +6372,7 @@ M68KMAKE_OP(move, 16, al, a)
 	uint res = MASK_OUT_ABOVE_16(AY);
 	uint ea = EA_AL_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6386,7 +6386,7 @@ M68KMAKE_OP(move, 16, al, .)
 	uint res = M68KMAKE_GET_OPER_AY_16;
 	uint ea = EA_AL_16();
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -6442,7 +6442,7 @@ M68KMAKE_OP(move, 32, ai, d)
 	uint res = DY;
 	uint ea = EA_AX_AI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6456,7 +6456,7 @@ M68KMAKE_OP(move, 32, ai, a)
 	uint res = AY;
 	uint ea = EA_AX_AI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6470,7 +6470,7 @@ M68KMAKE_OP(move, 32, ai, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AX_AI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6484,7 +6484,7 @@ M68KMAKE_OP(move, 32, pi, d)
 	uint res = DY;
 	uint ea = EA_AX_PI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6498,7 +6498,7 @@ M68KMAKE_OP(move, 32, pi, a)
 	uint res = AY;
 	uint ea = EA_AX_PI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6512,7 +6512,7 @@ M68KMAKE_OP(move, 32, pi, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AX_PI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6526,8 +6526,8 @@ M68KMAKE_OP(move, 32, pd, d)
 	uint res = DY;
 	uint ea = EA_AX_PD_32();
 
-	m68ki_write_16(ea+2, res & 0xFFFF );
-	m68ki_write_16(ea, (res >> 16) & 0xFFFF );
+	m68ki_write_16(state, ea+2, res & 0xFFFF );
+	m68ki_write_16(state, ea, (res >> 16) & 0xFFFF );
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6541,8 +6541,8 @@ M68KMAKE_OP(move, 32, pd, a)
 	uint res = AY;
 	uint ea = EA_AX_PD_32();
 
-	m68ki_write_16(ea+2, res & 0xFFFF );
-	m68ki_write_16(ea, (res >> 16) & 0xFFFF );
+	m68ki_write_16(state, ea+2, res & 0xFFFF );
+	m68ki_write_16(state, ea, (res >> 16) & 0xFFFF );
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6556,8 +6556,8 @@ M68KMAKE_OP(move, 32, pd, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AX_PD_32();
 
-	m68ki_write_16(ea+2, res & 0xFFFF );
-	m68ki_write_16(ea, (res >> 16) & 0xFFFF );
+	m68ki_write_16(state, ea+2, res & 0xFFFF );
+	m68ki_write_16(state, ea, (res >> 16) & 0xFFFF );
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6571,7 +6571,7 @@ M68KMAKE_OP(move, 32, di, d)
 	uint res = DY;
 	uint ea = EA_AX_DI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6585,7 +6585,7 @@ M68KMAKE_OP(move, 32, di, a)
 	uint res = AY;
 	uint ea = EA_AX_DI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6599,7 +6599,7 @@ M68KMAKE_OP(move, 32, di, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AX_DI_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6613,7 +6613,7 @@ M68KMAKE_OP(move, 32, ix, d)
 	uint res = DY;
 	uint ea = EA_AX_IX_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6627,7 +6627,7 @@ M68KMAKE_OP(move, 32, ix, a)
 	uint res = AY;
 	uint ea = EA_AX_IX_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6641,7 +6641,7 @@ M68KMAKE_OP(move, 32, ix, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AX_IX_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6655,7 +6655,7 @@ M68KMAKE_OP(move, 32, aw, d)
 	uint res = DY;
 	uint ea = EA_AW_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6669,7 +6669,7 @@ M68KMAKE_OP(move, 32, aw, a)
 	uint res = AY;
 	uint ea = EA_AW_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6683,7 +6683,7 @@ M68KMAKE_OP(move, 32, aw, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AW_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6697,7 +6697,7 @@ M68KMAKE_OP(move, 32, al, d)
 	uint res = DY;
 	uint ea = EA_AL_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6711,7 +6711,7 @@ M68KMAKE_OP(move, 32, al, a)
 	uint res = AY;
 	uint ea = EA_AL_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6725,7 +6725,7 @@ M68KMAKE_OP(move, 32, al, .)
 	uint res = M68KMAKE_GET_OPER_AY_32;
 	uint ea = EA_AL_32();
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -6777,7 +6777,7 @@ M68KMAKE_OP(move, 16, frc, d)
 		DY = MASK_OUT_BELOW_16(DY) | m68ki_get_ccr();
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -6785,10 +6785,10 @@ M68KMAKE_OP(move, 16, frc, .)
 {
 	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
 	{
-		m68ki_write_16(M68KMAKE_GET_EA_AY_16, m68ki_get_ccr());
+		m68ki_write_16(state, M68KMAKE_GET_EA_AY_16, m68ki_get_ccr());
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -6811,7 +6811,7 @@ M68KMAKE_OP(move, 16, frs, d)
 		DY = MASK_OUT_BELOW_16(DY) | m68ki_get_sr();
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -6820,10 +6820,10 @@ M68KMAKE_OP(move, 16, frs, .)
 	if(CPU_TYPE_IS_000(CPU_TYPE) || FLAG_S)	/* NS990408 */
 	{
 		uint ea = M68KMAKE_GET_EA_AY_16;
-		m68ki_write_16(ea, m68ki_get_sr());
+		m68ki_write_16(state, ea, m68ki_get_sr());
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -6834,7 +6834,7 @@ M68KMAKE_OP(move, 16, tos, d)
 		m68ki_set_sr(state, DY);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -6847,7 +6847,7 @@ M68KMAKE_OP(move, 16, tos, .)
 		m68ki_set_sr(state, new_sr);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -6858,7 +6858,7 @@ M68KMAKE_OP(move, 32, fru, .)
 		AY = REG_USP;
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -6870,7 +6870,7 @@ M68KMAKE_OP(move, 32, tou, .)
 		REG_USP = AY;
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -6910,7 +6910,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = REG_CAAR;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				break;
 			case 0x803:			   /* MSP */
 				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
@@ -6918,7 +6918,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = FLAG_M ? REG_SP : REG_MSP;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x804:			   /* ISP */
 				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
@@ -6926,7 +6926,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = FLAG_M ? REG_ISP : REG_SP;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x003:				/* TC */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6934,7 +6934,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_tc;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x004:				/* ITT0 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6942,7 +6942,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_itt0;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x005:				/* ITT1 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6950,7 +6950,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_itt1;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x006:				/* DTT0 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6958,7 +6958,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_dtt0;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x007:				/* DTT1 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6966,7 +6966,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_dtt1;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x805:				/* MMUSR */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6974,7 +6974,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_sr_040;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x806:				/* URP */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6982,7 +6982,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_urp_aptr;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x807:				/* SRP */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -6990,17 +6990,17 @@ M68KMAKE_OP(movec, 32, cr, .)
 					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_srp_aptr;
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			default:
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			}
 		}
-		m68ki_exception_privilege_violation();
+		m68ki_exception_privilege_violation(state);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -7044,7 +7044,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					}
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x800:			   /* USP */
 				REG_USP = REG_DA[(word2 >> 12) & 15];
@@ -7058,7 +7058,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					REG_CAAR = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x803:			   /* MSP */
 				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
@@ -7072,7 +7072,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					REG_SP = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x804:			   /* ISP */
 				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
@@ -7085,7 +7085,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					REG_ISP = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x003:			/* TC */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7102,7 +7102,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					}
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x004:			/* ITT0 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7110,7 +7110,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_itt0 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x005:			/* ITT1 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7118,7 +7118,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_itt1 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x006:			/* DTT0 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7126,7 +7126,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_dtt0 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x007:			/* DTT1 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7134,7 +7134,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_dtt1 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x805:			/* MMUSR */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7142,7 +7142,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_sr_040 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x806:			/* URP */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7150,7 +7150,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_urp_aptr = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			case 0x807:			/* SRP */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
@@ -7158,17 +7158,17 @@ M68KMAKE_OP(movec, 32, rc, .)
 					m68ki_cpu.mmu_srp_aptr = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			default:
-				m68ki_exception_illegal();
+				m68ki_exception_illegal(state);
 				return;
 			}
 		}
-		m68ki_exception_privilege_violation();
+		m68ki_exception_privilege_violation(state);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -7183,7 +7183,7 @@ M68KMAKE_OP(movem, 16, re, pd)
 		if(register_list & (1 << i))
 		{
 			ea -= 2;
-			m68ki_write_16(ea, MASK_OUT_ABOVE_16(REG_DA[15-i]));
+			m68ki_write_16(state, ea, MASK_OUT_ABOVE_16(REG_DA[15-i]));
 			count++;
 		}
 	AY = ea;
@@ -7202,7 +7202,7 @@ M68KMAKE_OP(movem, 16, re, .)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			m68ki_write_16(ea, MASK_OUT_ABOVE_16(REG_DA[i]));
+			m68ki_write_16(state, ea, MASK_OUT_ABOVE_16(REG_DA[i]));
 			ea += 2;
 			count++;
 		}
@@ -7222,8 +7222,8 @@ M68KMAKE_OP(movem, 32, re, pd)
 		if(register_list & (1 << i))
 		{
 			ea -= 4;
-			m68ki_write_16(ea+2, REG_DA[15-i] & 0xFFFF );
-			m68ki_write_16(ea, (REG_DA[15-i] >> 16) & 0xFFFF );
+			m68ki_write_16(state, ea+2, REG_DA[15-i] & 0xFFFF );
+			m68ki_write_16(state, ea, (REG_DA[15-i] >> 16) & 0xFFFF );
 			count++;
 		}
 	AY = ea;
@@ -7242,7 +7242,7 @@ M68KMAKE_OP(movem, 32, re, .)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			m68ki_write_32(ea, REG_DA[i]);
+			m68ki_write_32(state, ea, REG_DA[i]);
 			ea += 4;
 			count++;
 		}
@@ -7261,7 +7261,7 @@ M68KMAKE_OP(movem, 16, er, pi)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_16(ea)));
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_16(state, ea)));
 			ea += 2;
 			count++;
 		}
@@ -7281,7 +7281,7 @@ M68KMAKE_OP(movem, 16, er, pcdi)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_pcrel_16(ea)));
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_pcrel_16(state, ea)));
 			ea += 2;
 			count++;
 		}
@@ -7300,7 +7300,7 @@ M68KMAKE_OP(movem, 16, er, pcix)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_pcrel_16(ea)));
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_pcrel_16(state, ea)));
 			ea += 2;
 			count++;
 		}
@@ -7319,7 +7319,7 @@ M68KMAKE_OP(movem, 16, er, .)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_16(ea)));
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_16(state, ea)));
 			ea += 2;
 			count++;
 		}
@@ -7338,7 +7338,7 @@ M68KMAKE_OP(movem, 32, er, pi)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = m68ki_read_32(ea);
+			REG_DA[i] = m68ki_read_32(state, ea);
 			ea += 4;
 			count++;
 		}
@@ -7358,7 +7358,7 @@ M68KMAKE_OP(movem, 32, er, pcdi)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = m68ki_read_pcrel_32(ea);
+			REG_DA[i] = m68ki_read_pcrel_32(state, ea);
 			ea += 4;
 			count++;
 		}
@@ -7377,7 +7377,7 @@ M68KMAKE_OP(movem, 32, er, pcix)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = m68ki_read_pcrel_32(ea);
+			REG_DA[i] = m68ki_read_pcrel_32(state, ea);
 			ea += 4;
 			count++;
 		}
@@ -7396,7 +7396,7 @@ M68KMAKE_OP(movem, 32, er, .)
 	for(; i < 16; i++)
 		if(register_list & (1 << i))
 		{
-			REG_DA[i] = m68ki_read_32(ea);
+			REG_DA[i] = m68ki_read_32(state, ea);
 			ea += 4;
 			count++;
 		}
@@ -7410,8 +7410,8 @@ M68KMAKE_OP(movep, 16, re, .)
 	uint ea = EA_AY_DI_16();
 	uint src = DX;
 
-	m68ki_write_8(ea, MASK_OUT_ABOVE_8(src >> 8));
-	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src));
+	m68ki_write_8(state, ea, MASK_OUT_ABOVE_8(src >> 8));
+	m68ki_write_8(state, ea += 2, MASK_OUT_ABOVE_8(src));
 }
 
 
@@ -7420,10 +7420,10 @@ M68KMAKE_OP(movep, 32, re, .)
 	uint ea = EA_AY_DI_32();
 	uint src = DX;
 
-	m68ki_write_8(ea, MASK_OUT_ABOVE_8(src >> 24));
-	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src >> 16));
-	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src >> 8));
-	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src));
+	m68ki_write_8(state, ea, MASK_OUT_ABOVE_8(src >> 24));
+	m68ki_write_8(state, ea += 2, MASK_OUT_ABOVE_8(src >> 16));
+	m68ki_write_8(state, ea += 2, MASK_OUT_ABOVE_8(src >> 8));
+	m68ki_write_8(state, ea += 2, MASK_OUT_ABOVE_8(src));
 }
 
 
@@ -7432,7 +7432,7 @@ M68KMAKE_OP(movep, 16, er, .)
 	uint ea = EA_AY_DI_16();
 	uint* r_dst = &DX;
 
-	*r_dst = MASK_OUT_BELOW_16(*r_dst) | ((m68ki_read_8(ea) << 8) + m68ki_read_8(ea + 2));
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | ((m68ki_read_8(state, ea) << 8) + m68ki_read_8(state, ea + 2));
 }
 
 
@@ -7440,8 +7440,8 @@ M68KMAKE_OP(movep, 32, er, .)
 {
 	uint ea = EA_AY_DI_32();
 
-	DX = (m68ki_read_8(ea) << 24) + (m68ki_read_8(ea + 2) << 16)
-		+ (m68ki_read_8(ea + 4) << 8) + m68ki_read_8(ea + 6);
+	DX = (m68ki_read_8(state, ea) << 24) + (m68ki_read_8(state, ea + 2) << 16)
+		+ (m68ki_read_8(state, ea + 4) << 8) + m68ki_read_8(state, ea + 6);
 }
 
 
@@ -7457,26 +7457,26 @@ M68KMAKE_OP(moves, 8, ., .)
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 			if(BIT_B(word2))		   /* Register to memory */
 			{
-				m68ki_write_8_fc(ea, REG_DFC, MASK_OUT_ABOVE_8(REG_DA[(word2 >> 12) & 15]));
+				m68ki_write_8_fc(state, ea, REG_DFC, MASK_OUT_ABOVE_8(REG_DA[(word2 >> 12) & 15]));
 				return;
 			}
 			if(BIT_F(word2))		   /* Memory to address register */
 			{
-				REG_A[(word2 >> 12) & 7] = MAKE_INT_8(m68ki_read_8_fc(ea, REG_SFC));
+				REG_A[(word2 >> 12) & 7] = MAKE_INT_8(m68ki_read_8_fc(state, ea, REG_SFC));
 				if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
 					USE_CYCLES(2);
 				return;
 			}
 			/* Memory to data register */
-			REG_D[(word2 >> 12) & 7] = MASK_OUT_BELOW_8(REG_D[(word2 >> 12) & 7]) | m68ki_read_8_fc(ea, REG_SFC);
+			REG_D[(word2 >> 12) & 7] = MASK_OUT_BELOW_8(REG_D[(word2 >> 12) & 7]) | m68ki_read_8_fc(state, ea, REG_SFC);
 			if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
 				USE_CYCLES(2);
 			return;
 		}
-		m68ki_exception_privilege_violation();
+		m68ki_exception_privilege_violation(state);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -7492,26 +7492,26 @@ M68KMAKE_OP(moves, 16, ., .)
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 			if(BIT_B(word2))		   /* Register to memory */
 			{
-				m68ki_write_16_fc(ea, REG_DFC, MASK_OUT_ABOVE_16(REG_DA[(word2 >> 12) & 15]));
+				m68ki_write_16_fc(state, ea, REG_DFC, MASK_OUT_ABOVE_16(REG_DA[(word2 >> 12) & 15]));
 				return;
 			}
 			if(BIT_F(word2))		   /* Memory to address register */
 			{
-				REG_A[(word2 >> 12) & 7] = MAKE_INT_16(m68ki_read_16_fc(ea, REG_SFC));
+				REG_A[(word2 >> 12) & 7] = MAKE_INT_16(m68ki_read_16_fc(state, ea, REG_SFC));
 				if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
 					USE_CYCLES(2);
 				return;
 			}
 			/* Memory to data register */
-			REG_D[(word2 >> 12) & 7] = MASK_OUT_BELOW_16(REG_D[(word2 >> 12) & 7]) | m68ki_read_16_fc(ea, REG_SFC);
+			REG_D[(word2 >> 12) & 7] = MASK_OUT_BELOW_16(REG_D[(word2 >> 12) & 7]) | m68ki_read_16_fc(state, ea, REG_SFC);
 			if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
 				USE_CYCLES(2);
 			return;
 		}
-		m68ki_exception_privilege_violation();
+		m68ki_exception_privilege_violation(state);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -7527,21 +7527,21 @@ M68KMAKE_OP(moves, 32, ., .)
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 			if(BIT_B(word2))		   /* Register to memory */
 			{
-				m68ki_write_32_fc(ea, REG_DFC, REG_DA[(word2 >> 12) & 15]);
+				m68ki_write_32_fc(state, ea, REG_DFC, REG_DA[(word2 >> 12) & 15]);
 				if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
 					USE_CYCLES(2);
 				return;
 			}
 			/* Memory to register */
-			REG_DA[(word2 >> 12) & 15] = m68ki_read_32_fc(ea, REG_SFC);
+			REG_DA[(word2 >> 12) & 15] = m68ki_read_32_fc(state, ea, REG_SFC);
 			if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
 				USE_CYCLES(2);
 			return;
 		}
-		m68ki_exception_privilege_violation();
+		m68ki_exception_privilege_violation(state);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -7562,10 +7562,10 @@ M68KMAKE_OP(move16, 32, ., .)
 	int ax = REG_IR & 7;
 	int ay = (w2 >> 12) & 7;
 
-	m68ki_write_32(REG_A[ay],    m68ki_read_32(REG_A[ax]));
-	m68ki_write_32(REG_A[ay]+4,  m68ki_read_32(REG_A[ax]+4));
-	m68ki_write_32(REG_A[ay]+8,  m68ki_read_32(REG_A[ax]+8));
-	m68ki_write_32(REG_A[ay]+12, m68ki_read_32(REG_A[ax]+12));
+	m68ki_write_32(state, REG_A[ay],    m68ki_read_32(state, REG_A[ax]));
+	m68ki_write_32(state, REG_A[ay]+4,  m68ki_read_32(state, REG_A[ax]+4));
+	m68ki_write_32(state, REG_A[ay]+8,  m68ki_read_32(state, REG_A[ax]+8));
+	m68ki_write_32(state, REG_A[ay]+12, m68ki_read_32(state, REG_A[ax]+12));
 
 	REG_A[ax] += 16;
 	REG_A[ay] += 16;
@@ -7676,7 +7676,7 @@ M68KMAKE_OP(mull, 32, ., d)
 		REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #else
 
@@ -7746,7 +7746,7 @@ M68KMAKE_OP(mull, 32, ., d)
 			FLAG_V = (hi != 0) << 7;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #endif
 }
@@ -7800,7 +7800,7 @@ M68KMAKE_OP(mull, 32, ., .)
 		REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(res);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #else
 
@@ -7870,7 +7870,7 @@ M68KMAKE_OP(mull, 32, ., .)
 			FLAG_V = (hi != 0) << 7;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 
 #endif
 }
@@ -7912,7 +7912,7 @@ M68KMAKE_OP(nbcd, 8, ., d)
 M68KMAKE_OP(nbcd, 8, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = - dst - XFLAG_AS_1();
 
 	if(res != 0)
@@ -7926,7 +7926,7 @@ M68KMAKE_OP(nbcd, 8, ., .)
 
 		FLAG_V &= ~res; /* Undefined V behavior part II */
 
-		m68ki_write_8(ea, MASK_OUT_ABOVE_8(res));
+		m68ki_write_8(state, ea, MASK_OUT_ABOVE_8(res));
 
 		FLAG_Z |= res;
 		FLAG_C = CFLAG_SET;
@@ -7959,7 +7959,7 @@ M68KMAKE_OP(neg, 8, ., d)
 M68KMAKE_OP(neg, 8, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 	uint res = 0 - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -7967,7 +7967,7 @@ M68KMAKE_OP(neg, 8, ., .)
 	FLAG_V = src & res;
 	FLAG_Z = MASK_OUT_ABOVE_8(res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -7988,7 +7988,7 @@ M68KMAKE_OP(neg, 16, ., d)
 M68KMAKE_OP(neg, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = 0 - src;
 
 	FLAG_N = NFLAG_16(res);
@@ -7996,7 +7996,7 @@ M68KMAKE_OP(neg, 16, ., .)
 	FLAG_V = (src & res)>>8;
 	FLAG_Z = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -8017,7 +8017,7 @@ M68KMAKE_OP(neg, 32, ., d)
 M68KMAKE_OP(neg, 32, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint src = m68ki_read_32(ea);
+	uint src = m68ki_read_32(state, ea);
 	uint res = 0 - src;
 
 	FLAG_N = NFLAG_32(res);
@@ -8025,7 +8025,7 @@ M68KMAKE_OP(neg, 32, ., .)
 	FLAG_V = (src & res)>>24;
 	FLAG_Z = MASK_OUT_ABOVE_32(res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -8048,7 +8048,7 @@ M68KMAKE_OP(negx, 8, ., d)
 M68KMAKE_OP(negx, 8, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint src = m68ki_read_8(ea);
+	uint src = m68ki_read_8(state, ea);
 	uint res = 0 - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -8058,7 +8058,7 @@ M68KMAKE_OP(negx, 8, ., .)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -8081,7 +8081,7 @@ M68KMAKE_OP(negx, 16, ., d)
 M68KMAKE_OP(negx, 16, ., .)
 {
 	uint ea  = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = 0 - MASK_OUT_ABOVE_16(src) - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_16(res);
@@ -8091,7 +8091,7 @@ M68KMAKE_OP(negx, 16, ., .)
 	res = MASK_OUT_ABOVE_16(res);
 	FLAG_Z |= res;
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 }
 
 
@@ -8114,7 +8114,7 @@ M68KMAKE_OP(negx, 32, ., d)
 M68KMAKE_OP(negx, 32, ., .)
 {
 	uint ea  = M68KMAKE_GET_EA_AY_32;
-	uint src = m68ki_read_32(ea);
+	uint src = m68ki_read_32(state, ea);
 	uint res = 0 - MASK_OUT_ABOVE_32(src) - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_32(res);
@@ -8124,7 +8124,7 @@ M68KMAKE_OP(negx, 32, ., .)
 	res = MASK_OUT_ABOVE_32(res);
 	FLAG_Z |= res;
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 }
 
 
@@ -8151,9 +8151,9 @@ M68KMAKE_OP(not, 8, ., d)
 M68KMAKE_OP(not, 8, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = MASK_OUT_ABOVE_8(~m68ki_read_8(ea));
+	uint res = MASK_OUT_ABOVE_8(~m68ki_read_8(state, ea));
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -8179,9 +8179,9 @@ M68KMAKE_OP(not, 16, ., d)
 M68KMAKE_OP(not, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = MASK_OUT_ABOVE_16(~m68ki_read_16(ea));
+	uint res = MASK_OUT_ABOVE_16(~m68ki_read_16(state, ea));
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -8205,9 +8205,9 @@ M68KMAKE_OP(not, 32, ., d)
 M68KMAKE_OP(not, 32, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = MASK_OUT_ABOVE_32(~m68ki_read_32(ea));
+	uint res = MASK_OUT_ABOVE_32(~m68ki_read_32(state, ea));
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -8285,9 +8285,9 @@ M68KMAKE_OP(or, 32, er, .)
 M68KMAKE_OP(or, 8, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = MASK_OUT_ABOVE_8(DX | m68ki_read_8(ea));
+	uint res = MASK_OUT_ABOVE_8(DX | m68ki_read_8(state, ea));
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -8299,9 +8299,9 @@ M68KMAKE_OP(or, 8, re, .)
 M68KMAKE_OP(or, 16, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = MASK_OUT_ABOVE_16(DX | m68ki_read_16(ea));
+	uint res = MASK_OUT_ABOVE_16(DX | m68ki_read_16(state, ea));
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -8313,9 +8313,9 @@ M68KMAKE_OP(or, 16, re, .)
 M68KMAKE_OP(or, 32, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = DX | m68ki_read_32(ea);
+	uint res = DX | m68ki_read_32(state, ea);
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -8339,9 +8339,9 @@ M68KMAKE_OP(ori, 8, ., .)
 {
 	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint res = MASK_OUT_ABOVE_8(src | m68ki_read_8(ea));
+	uint res = MASK_OUT_ABOVE_8(src | m68ki_read_8(state, ea));
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 
 	FLAG_N = NFLAG_8(res);
 	FLAG_Z = res;
@@ -8365,9 +8365,9 @@ M68KMAKE_OP(ori, 16, ., .)
 {
 	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint res = MASK_OUT_ABOVE_16(src | m68ki_read_16(ea));
+	uint res = MASK_OUT_ABOVE_16(src | m68ki_read_16(state, ea));
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -8391,9 +8391,9 @@ M68KMAKE_OP(ori, 32, ., .)
 {
 	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint res = src | m68ki_read_32(ea);
+	uint res = src | m68ki_read_32(state, ea);
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 
 	FLAG_N = NFLAG_32(res);
 	FLAG_Z = res;
@@ -8417,7 +8417,7 @@ M68KMAKE_OP(ori, 16, tos, .)
 		m68ki_set_sr(state, m68ki_get_sr() | src);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -8432,7 +8432,7 @@ M68KMAKE_OP(pack, 16, rr, .)
 		*r_dst = MASK_OUT_BELOW_8(*r_dst) | ((src >> 4) & 0x00f0) | (src & 0x000f);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -8442,14 +8442,14 @@ M68KMAKE_OP(pack, 16, mm, ax7)
 	{
 		/* Note: AX and AY are reversed in Motorola's docs */
 		uint ea_src = EA_AY_PD_8();
-		uint src = m68ki_read_8(ea_src);
+		uint src = m68ki_read_8(state, ea_src);
 		ea_src = EA_AY_PD_8();
-		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16(state);
+		src = ((src << 8) | m68ki_read_8(state, ea_src)) + OPER_I_16(state);
 
-		m68ki_write_8(EA_A7_PD_8(), ((src >> 8) & 0x000f) | ((src<<4) & 0x00f0));
+		m68ki_write_8(state, EA_A7_PD_8(), ((src >> 8) & 0x000f) | ((src<<4) & 0x00f0));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -8459,14 +8459,14 @@ M68KMAKE_OP(pack, 16, mm, ay7)
 	{
 		/* Note: AX and AY are reversed in Motorola's docs */
 		uint ea_src = EA_A7_PD_8();
-		uint src = m68ki_read_8(ea_src);
+		uint src = m68ki_read_8(state, ea_src);
 		ea_src = EA_A7_PD_8();
-		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16(state);
+		src = (src | (m68ki_read_8(state, ea_src) << 8)) + OPER_I_16(state);
 
-		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		m68ki_write_8(state, EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -8475,14 +8475,14 @@ M68KMAKE_OP(pack, 16, mm, axy7)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		uint ea_src = EA_A7_PD_8();
-		uint src = m68ki_read_8(ea_src);
+		uint src = m68ki_read_8(state, ea_src);
 		ea_src = EA_A7_PD_8();
-		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16(state);
+		src = (src | (m68ki_read_8(state, ea_src) << 8)) + OPER_I_16(state);
 
-		m68ki_write_8(EA_A7_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		m68ki_write_8(state, EA_A7_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -8492,14 +8492,14 @@ M68KMAKE_OP(pack, 16, mm, .)
 	{
 		/* Note: AX and AY are reversed in Motorola's docs */
 		uint ea_src = EA_AY_PD_8();
-		uint src = m68ki_read_8(ea_src);
+		uint src = m68ki_read_8(state, ea_src);
 		ea_src = EA_AY_PD_8();
-		src = (src | (m68ki_read_8(ea_src) << 8)) + OPER_I_16(state);
+		src = (src | (m68ki_read_8(state, ea_src) << 8)) + OPER_I_16(state);
 
-		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		m68ki_write_8(state, EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -8507,7 +8507,7 @@ M68KMAKE_OP(pea, 32, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
 
-	m68ki_push_32(ea);
+	m68ki_push_32(state, ea);
 }
 
 M68KMAKE_OP(pflusha, 32, ., .)
@@ -8517,7 +8517,7 @@ M68KMAKE_OP(pflusha, 32, ., .)
 		fprintf(stderr,"68040: unhandled PFLUSHA (ir=%04x)\n", REG_IR);
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 M68KMAKE_OP(pflushan, 32, ., .)
@@ -8527,18 +8527,18 @@ M68KMAKE_OP(pflushan, 32, ., .)
 		fprintf(stderr,"68040: unhandled PFLUSHAN (ir=%04x)\n", REG_IR);
 		return;
 	}
-	m68ki_exception_1111();
+	m68ki_exception_1111(state);
 }
 
 M68KMAKE_OP(pmmu, 32, ., .)
 {
 	if ((CPU_TYPE_IS_EC020_PLUS(CPU_TYPE)) && (HAS_PMMU))
 	{
-		void m68851_mmu_ops(m68ki_cpu_core *state);
+		m68851_mmu_ops(state);
 	}
 	else
 	{
-		m68ki_exception_1111();
+		m68ki_exception_1111(state);
 	}
 }
 
@@ -8550,7 +8550,7 @@ M68KMAKE_OP(reset, 0, ., .)
 		USE_CYCLES(CYC_RESET);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -8696,10 +8696,10 @@ M68KMAKE_OP(ror, 32, r, .)
 M68KMAKE_OP(ror, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = ROR_16(src, 1);
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -8867,10 +8867,10 @@ M68KMAKE_OP(rol, 32, r, .)
 M68KMAKE_OP(rol, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = MASK_OUT_ABOVE_16(ROL_16(src, 1));
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -9089,13 +9089,13 @@ M68KMAKE_OP(roxr, 32, r, .)
 M68KMAKE_OP(roxr, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = ROR_17(src | (XFLAG_AS_1() << 16), 1);
 
 	FLAG_C = FLAG_X = res >> 8;
 	res = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -9314,13 +9314,13 @@ M68KMAKE_OP(roxl, 32, r, .)
 M68KMAKE_OP(roxl, 16, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint src = m68ki_read_16(ea);
+	uint src = m68ki_read_16(state, ea);
 	uint res = ROL_17(src | (XFLAG_AS_1() << 16), 1);
 
 	FLAG_C = FLAG_X = res >> 8;
 	res = MASK_OUT_ABOVE_16(res);
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 
 	FLAG_N = NFLAG_16(res);
 	FLAG_Z = res;
@@ -9332,14 +9332,14 @@ M68KMAKE_OP(rtd, 32, ., .)
 {
 	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
 	{
-		uint new_pc = m68ki_pull_32();
+		uint new_pc = m68ki_pull_32(state);
 
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
 		m68ki_jump(new_pc);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -9356,8 +9356,8 @@ M68KMAKE_OP(rte, 32, ., .)
 
 		if(CPU_TYPE_IS_000(CPU_TYPE))
 		{
-			new_sr = m68ki_pull_16();
-			new_pc = m68ki_pull_32();
+			new_sr = m68ki_pull_16(state);
+			new_pc = m68ki_pull_32(state);
 			m68ki_jump(new_pc);
 			m68ki_set_sr(state, new_sr);
 
@@ -9369,12 +9369,12 @@ M68KMAKE_OP(rte, 32, ., .)
 
 		if(CPU_TYPE_IS_010(CPU_TYPE))
 		{
-			format_word = m68ki_read_16(REG_A[7]+6) >> 12;
+			format_word = m68ki_read_16(state, REG_A[7]+6) >> 12;
 			if(format_word == 0)
 			{
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();	/* format word */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);	/* format word */
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
@@ -9382,84 +9382,84 @@ M68KMAKE_OP(rte, 32, ., .)
 				return;
 			} else if (format_word == 8) {
 				/* Format 8 stack frame -- 68010 only. 29 word bus/address error */
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();	/* format word */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);	/* format word */
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
-				m68ki_fake_pull_16();  /* special status */
-				m68ki_fake_pull_32();	/* fault address */
-				m68ki_fake_pull_32();  /* reserved and data output buffer */
-				m68ki_fake_pull_32();  /* reserved and data input buffer */
-				m68ki_fake_pull_32();  /* reserved and instruction input buffer */
-				m68ki_fake_pull_32();  /* 8 dwords of CPU specific undocumented data */
-				m68ki_fake_pull_32();
-				m68ki_fake_pull_32();
-				m68ki_fake_pull_32();
-				m68ki_fake_pull_32();
-				m68ki_fake_pull_32();
-				m68ki_fake_pull_32();
-				m68ki_fake_pull_32();
+				m68ki_fake_pull_16(state);  /* special status */
+				m68ki_fake_pull_32(state);	/* fault address */
+				m68ki_fake_pull_32(state);  /* reserved and data output buffer */
+				m68ki_fake_pull_32(state);  /* reserved and data input buffer */
+				m68ki_fake_pull_32(state);  /* reserved and instruction input buffer */
+				m68ki_fake_pull_32(state);  /* 8 dwords of CPU specific undocumented data */
+				m68ki_fake_pull_32(state);
+				m68ki_fake_pull_32(state);
+				m68ki_fake_pull_32(state);
+				m68ki_fake_pull_32(state);
+				m68ki_fake_pull_32(state);
+				m68ki_fake_pull_32(state);
+				m68ki_fake_pull_32(state);
 				return;
 			}
 			CPU_INSTR_MODE = INSTRUCTION_YES;
 			CPU_RUN_MODE = RUN_MODE_NORMAL;
 			/* Not handling other exception types (9) */
-			m68ki_exception_format_error();
+			m68ki_exception_format_error(state);
 			return;
 		}
 
 		/* Otherwise it's 020 */
 rte_loop:
-		format_word = m68ki_read_16(REG_A[7]+6) >> 12;
+		format_word = m68ki_read_16(state, REG_A[7]+6) >> 12;
 		switch(format_word)
 		{
 			case 0: /* Normal */
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();	/* format word */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);	/* format word */
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
 			case 1: /* Throwaway */
-				new_sr = m68ki_pull_16();
-				m68ki_fake_pull_32();	/* program counter */
-				m68ki_fake_pull_16();	/* format word */
+				new_sr = m68ki_pull_16(state);
+				m68ki_fake_pull_32(state);	/* program counter */
+				m68ki_fake_pull_16(state);	/* format word */
 				m68ki_set_sr_noint(state, new_sr);
 				goto rte_loop;
 			case 2: /* Trap */
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();	/* format word */
-				m68ki_fake_pull_32();	/* address */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);	/* format word */
+				m68ki_fake_pull_32(state);	/* address */
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
 			case 7: /* 68040 access error */
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();   /* $06: format word */
-				m68ki_fake_pull_32();   /* $08: effective address */
-				m68ki_fake_pull_16();   /* $0c: special status word */
-				m68ki_fake_pull_16();   /* $0e: wb3s */
-				m68ki_fake_pull_16();   /* $10: wb2s */
-				m68ki_fake_pull_16();   /* $12: wb1s */
-				m68ki_fake_pull_32();   /* $14: data fault address */
-				m68ki_fake_pull_32();   /* $18: wb3a */
-				m68ki_fake_pull_32();   /* $1c: wb3d */
-				m68ki_fake_pull_32();   /* $20: wb2a */
-				m68ki_fake_pull_32();   /* $24: wb2d */
-				m68ki_fake_pull_32();   /* $28: wb1a */
-				m68ki_fake_pull_32();   /* $2c: wb1d/pd0 */
-				m68ki_fake_pull_32();   /* $30: pd1 */
-				m68ki_fake_pull_32();   /* $34: pd2 */
-				m68ki_fake_pull_32();   /* $38: pd3 */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);   /* $06: format word */
+				m68ki_fake_pull_32(state);   /* $08: effective address */
+				m68ki_fake_pull_16(state);   /* $0c: special status word */
+				m68ki_fake_pull_16(state);   /* $0e: wb3s */
+				m68ki_fake_pull_16(state);   /* $10: wb2s */
+				m68ki_fake_pull_16(state);   /* $12: wb1s */
+				m68ki_fake_pull_32(state);   /* $14: data fault address */
+				m68ki_fake_pull_32(state);   /* $18: wb3a */
+				m68ki_fake_pull_32(state);   /* $1c: wb3d */
+				m68ki_fake_pull_32(state);   /* $20: wb2a */
+				m68ki_fake_pull_32(state);   /* $24: wb2d */
+				m68ki_fake_pull_32(state);   /* $28: wb1a */
+				m68ki_fake_pull_32(state);   /* $2c: wb1d/pd0 */
+				m68ki_fake_pull_32(state);   /* $30: pd1 */
+				m68ki_fake_pull_32(state);   /* $34: pd2 */
+				m68ki_fake_pull_32(state);   /* $38: pd3 */
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
@@ -9467,17 +9467,17 @@ rte_loop:
 				return;
 
 			case 0x0a: /* Bus Error at instruction boundary */
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();   /* $06: format word */
-				m68ki_fake_pull_16();   /* $08: internal register */
-				m68ki_fake_pull_16();   /* $0a: special status word */
-				m68ki_fake_pull_16();   /* $0c: instruction pipe stage c */
-				m68ki_fake_pull_16();   /* $0e: instruction pipe stage b */
-				m68ki_fake_pull_32();   /* $10: data fault address */
-				m68ki_fake_pull_32();   /* $14: internal registers */
-				m68ki_fake_pull_32();   /* $18: data output buffer */
-				m68ki_fake_pull_32();   /* $1c: internal registers */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);   /* $06: format word */
+				m68ki_fake_pull_16(state);   /* $08: internal register */
+				m68ki_fake_pull_16(state);   /* $0a: special status word */
+				m68ki_fake_pull_16(state);   /* $0c: instruction pipe stage c */
+				m68ki_fake_pull_16(state);   /* $0e: instruction pipe stage b */
+				m68ki_fake_pull_32(state);   /* $10: data fault address */
+				m68ki_fake_pull_32(state);   /* $14: internal registers */
+				m68ki_fake_pull_32(state);   /* $18: data output buffer */
+				m68ki_fake_pull_32(state);   /* $1c: internal registers */
 
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
@@ -9486,33 +9486,33 @@ rte_loop:
 				return;
 
 			case 0x0b: /* Bus Error - Instruction Execution in Progress */
-				new_sr = m68ki_pull_16();
-				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();   /* $06: format word */
-				m68ki_fake_pull_16();   /* $08: internal register */
-				m68ki_fake_pull_16();   /* $0a: special status word */
-				m68ki_fake_pull_16();   /* $0c: instruction pipe stage c */
-				m68ki_fake_pull_16();   /* $0e: instruction pipe stage b */
-				m68ki_fake_pull_32();   /* $10: data fault address */
-				m68ki_fake_pull_32();   /* $14: internal registers */
-				m68ki_fake_pull_32();   /* $18: data output buffer */
-				m68ki_fake_pull_32();   /* $1c: internal registers */
-				m68ki_fake_pull_32();   /* $20:  */
-				m68ki_fake_pull_32();   /* $24: stage B address */
-				m68ki_fake_pull_32();   /* $28:  */
-				m68ki_fake_pull_32();   /* $2c: data input buffer */
-				m68ki_fake_pull_32();   /* $30:  */
-				m68ki_fake_pull_16();   /* $34:  */
-				m68ki_fake_pull_16();   /* $36: version #, internal information */
-				m68ki_fake_pull_32();   /* $38:  */
-				m68ki_fake_pull_32();   /* $3c:  */
-				m68ki_fake_pull_32();   /* $40:  */
-				m68ki_fake_pull_32();   /* $44:  */
-				m68ki_fake_pull_32();   /* $48:  */
-				m68ki_fake_pull_32();   /* $4c:  */
-				m68ki_fake_pull_32();   /* $50:  */
-				m68ki_fake_pull_32();   /* $54:  */
-				m68ki_fake_pull_32();   /* $58:  */
+				new_sr = m68ki_pull_16(state);
+				new_pc = m68ki_pull_32(state);
+				m68ki_fake_pull_16(state);   /* $06: format word */
+				m68ki_fake_pull_16(state);   /* $08: internal register */
+				m68ki_fake_pull_16(state);   /* $0a: special status word */
+				m68ki_fake_pull_16(state);   /* $0c: instruction pipe stage c */
+				m68ki_fake_pull_16(state);   /* $0e: instruction pipe stage b */
+				m68ki_fake_pull_32(state);   /* $10: data fault address */
+				m68ki_fake_pull_32(state);   /* $14: internal registers */
+				m68ki_fake_pull_32(state);   /* $18: data output buffer */
+				m68ki_fake_pull_32(state);   /* $1c: internal registers */
+				m68ki_fake_pull_32(state);   /* $20:  */
+				m68ki_fake_pull_32(state);   /* $24: stage B address */
+				m68ki_fake_pull_32(state);   /* $28:  */
+				m68ki_fake_pull_32(state);   /* $2c: data input buffer */
+				m68ki_fake_pull_32(state);   /* $30:  */
+				m68ki_fake_pull_16(state);   /* $34:  */
+				m68ki_fake_pull_16(state);   /* $36: version #, internal information */
+				m68ki_fake_pull_32(state);   /* $38:  */
+				m68ki_fake_pull_32(state);   /* $3c:  */
+				m68ki_fake_pull_32(state);   /* $40:  */
+				m68ki_fake_pull_32(state);   /* $44:  */
+				m68ki_fake_pull_32(state);   /* $48:  */
+				m68ki_fake_pull_32(state);   /* $4c:  */
+				m68ki_fake_pull_32(state);   /* $50:  */
+				m68ki_fake_pull_32(state);   /* $54:  */
+				m68ki_fake_pull_32(state);   /* $58:  */
 
 				m68ki_jump(new_pc);
 				m68ki_set_sr(state, new_sr);
@@ -9523,10 +9523,10 @@ rte_loop:
 		/* Not handling long or short bus fault */
 		CPU_INSTR_MODE = INSTRUCTION_YES;
 		CPU_RUN_MODE = RUN_MODE_NORMAL;
-		m68ki_exception_format_error();
+		m68ki_exception_format_error(state);
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -9540,22 +9540,22 @@ M68KMAKE_OP(rtm, 32, ., .)
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PC - 2),CPU_TYPE)));
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
 M68KMAKE_OP(rtr, 32, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_set_ccr(m68ki_pull_16());
-	m68ki_jump(m68ki_pull_32());
+	m68ki_set_ccr(m68ki_pull_16(state));
+	m68ki_jump(m68ki_pull_32(state));
 }
 
 
 M68KMAKE_OP(rts, 32, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_jump(m68ki_pull_32());
+	m68ki_jump(m68ki_pull_32(state));
 }
 
 
@@ -9593,7 +9593,7 @@ M68KMAKE_OP(sbcd, 8, mm, ax7)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
 	uint corf = 0;
 
@@ -9615,7 +9615,7 @@ M68KMAKE_OP(sbcd, 8, mm, ax7)
 	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -9623,7 +9623,7 @@ M68KMAKE_OP(sbcd, 8, mm, ay7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
 	uint corf = 0;
 
@@ -9645,7 +9645,7 @@ M68KMAKE_OP(sbcd, 8, mm, ay7)
 	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -9653,7 +9653,7 @@ M68KMAKE_OP(sbcd, 8, mm, axy7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
 	uint corf = 0;
 
@@ -9675,7 +9675,7 @@ M68KMAKE_OP(sbcd, 8, mm, axy7)
 	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -9683,7 +9683,7 @@ M68KMAKE_OP(sbcd, 8, mm, .)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
 	uint corf = 0;
 
@@ -9705,7 +9705,7 @@ M68KMAKE_OP(sbcd, 8, mm, .)
 	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -9717,7 +9717,7 @@ M68KMAKE_OP(st, 8, ., d)
 
 M68KMAKE_OP(st, 8, ., .)
 {
-	m68ki_write_8(M68KMAKE_GET_EA_AY_8, 0xff);
+	m68ki_write_8(state, M68KMAKE_GET_EA_AY_8, 0xff);
 }
 
 
@@ -9729,7 +9729,7 @@ M68KMAKE_OP(sf, 8, ., d)
 
 M68KMAKE_OP(sf, 8, ., .)
 {
-	m68ki_write_8(M68KMAKE_GET_EA_AY_8, 0);
+	m68ki_write_8(state, M68KMAKE_GET_EA_AY_8, 0);
 }
 
 
@@ -9747,7 +9747,7 @@ M68KMAKE_OP(scc, 8, ., d)
 
 M68KMAKE_OP(scc, 8, ., .)
 {
-	m68ki_write_8(M68KMAKE_GET_EA_AY_8, M68KMAKE_CC ? 0xff : 0);
+	m68ki_write_8(state, M68KMAKE_GET_EA_AY_8, M68KMAKE_CC ? 0xff : 0);
 }
 
 
@@ -9765,7 +9765,7 @@ M68KMAKE_OP(stop, 0, ., .)
 			USE_ALL_CYCLES();
 		return;
 	}
-	m68ki_exception_privilege_violation();
+	m68ki_exception_privilege_violation(state);
 }
 
 
@@ -9901,7 +9901,7 @@ M68KMAKE_OP(sub, 8, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
 	uint src = MASK_OUT_ABOVE_8(DX);
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -9909,7 +9909,7 @@ M68KMAKE_OP(sub, 8, re, .)
 	FLAG_X = FLAG_C = CFLAG_8(res);
 	FLAG_V = VFLAG_SUB_8(src, dst, res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -9917,7 +9917,7 @@ M68KMAKE_OP(sub, 16, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_16;
 	uint src = MASK_OUT_ABOVE_16(DX);
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_16(res);
@@ -9925,7 +9925,7 @@ M68KMAKE_OP(sub, 16, re, .)
 	FLAG_X = FLAG_C = CFLAG_16(res);
 	FLAG_V = VFLAG_SUB_16(src, dst, res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -9933,7 +9933,7 @@ M68KMAKE_OP(sub, 32, re, .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	uint src = DX;
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_32(res);
@@ -9941,7 +9941,7 @@ M68KMAKE_OP(sub, 32, re, .)
 	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
 	FLAG_V = VFLAG_SUB_32(src, dst, res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -10015,7 +10015,7 @@ M68KMAKE_OP(subi, 8, ., .)
 {
 	uint src = OPER_I_8(state);
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -10023,7 +10023,7 @@ M68KMAKE_OP(subi, 8, ., .)
 	FLAG_X = FLAG_C = CFLAG_8(res);
 	FLAG_V = VFLAG_SUB_8(src, dst, res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -10047,7 +10047,7 @@ M68KMAKE_OP(subi, 16, ., .)
 {
 	uint src = OPER_I_16(state);
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_16(res);
@@ -10055,7 +10055,7 @@ M68KMAKE_OP(subi, 16, ., .)
 	FLAG_X = FLAG_C = CFLAG_16(res);
 	FLAG_V = VFLAG_SUB_16(src, dst, res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -10079,7 +10079,7 @@ M68KMAKE_OP(subi, 32, ., .)
 {
 	uint src = OPER_I_32(state);
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_32(res);
@@ -10087,7 +10087,7 @@ M68KMAKE_OP(subi, 32, ., .)
 	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
 	FLAG_V = VFLAG_SUB_32(src, dst, res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -10111,7 +10111,7 @@ M68KMAKE_OP(subq, 8, ., .)
 {
 	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_8(res);
@@ -10119,7 +10119,7 @@ M68KMAKE_OP(subq, 8, ., .)
 	FLAG_X = FLAG_C = CFLAG_8(res);
 	FLAG_V = VFLAG_SUB_8(src, dst, res);
 
-	m68ki_write_8(ea, FLAG_Z);
+	m68ki_write_8(state, ea, FLAG_Z);
 }
 
 
@@ -10151,7 +10151,7 @@ M68KMAKE_OP(subq, 16, ., .)
 {
 	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
 	uint ea = M68KMAKE_GET_EA_AY_16;
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_16(res);
@@ -10159,7 +10159,7 @@ M68KMAKE_OP(subq, 16, ., .)
 	FLAG_X = FLAG_C = CFLAG_16(res);
 	FLAG_V = VFLAG_SUB_16(src, dst, res);
 
-	m68ki_write_16(ea, FLAG_Z);
+	m68ki_write_16(state, ea, FLAG_Z);
 }
 
 
@@ -10191,7 +10191,7 @@ M68KMAKE_OP(subq, 32, ., .)
 {
 	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
 	uint ea = M68KMAKE_GET_EA_AY_32;
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = dst - src;
 
 	FLAG_N = NFLAG_32(res);
@@ -10199,7 +10199,7 @@ M68KMAKE_OP(subq, 32, ., .)
 	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
 	FLAG_V = VFLAG_SUB_32(src, dst, res);
 
-	m68ki_write_32(ea, FLAG_Z);
+	m68ki_write_32(state, ea, FLAG_Z);
 }
 
 
@@ -10261,7 +10261,7 @@ M68KMAKE_OP(subx, 8, mm, ax7)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -10271,7 +10271,7 @@ M68KMAKE_OP(subx, 8, mm, ax7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -10279,7 +10279,7 @@ M68KMAKE_OP(subx, 8, mm, ay7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -10289,7 +10289,7 @@ M68KMAKE_OP(subx, 8, mm, ay7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -10297,7 +10297,7 @@ M68KMAKE_OP(subx, 8, mm, axy7)
 {
 	uint src = OPER_A7_PD_8(state);
 	uint ea  = EA_A7_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -10307,7 +10307,7 @@ M68KMAKE_OP(subx, 8, mm, axy7)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -10315,7 +10315,7 @@ M68KMAKE_OP(subx, 8, mm, .)
 {
 	uint src = OPER_AY_PD_8(state);
 	uint ea  = EA_AX_PD_8();
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint res = dst - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_8(res);
@@ -10325,7 +10325,7 @@ M68KMAKE_OP(subx, 8, mm, .)
 	res = MASK_OUT_ABOVE_8(res);
 	FLAG_Z |= res;
 
-	m68ki_write_8(ea, res);
+	m68ki_write_8(state, ea, res);
 }
 
 
@@ -10333,7 +10333,7 @@ M68KMAKE_OP(subx, 16, mm, .)
 {
 	uint src = OPER_AY_PD_16(state);
 	uint ea  = EA_AX_PD_16();
-	uint dst = m68ki_read_16(ea);
+	uint dst = m68ki_read_16(state, ea);
 	uint res = dst - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_16(res);
@@ -10343,7 +10343,7 @@ M68KMAKE_OP(subx, 16, mm, .)
 	res = MASK_OUT_ABOVE_16(res);
 	FLAG_Z |= res;
 
-	m68ki_write_16(ea, res);
+	m68ki_write_16(state, ea, res);
 }
 
 
@@ -10351,7 +10351,7 @@ M68KMAKE_OP(subx, 32, mm, .)
 {
 	uint src = OPER_AY_PD_32(state);
 	uint ea  = EA_AX_PD_32();
-	uint dst = m68ki_read_32(ea);
+	uint dst = m68ki_read_32(state, ea);
 	uint res = dst - src - XFLAG_AS_1();
 
 	FLAG_N = NFLAG_32(res);
@@ -10361,7 +10361,7 @@ M68KMAKE_OP(subx, 32, mm, .)
 	res = MASK_OUT_ABOVE_32(res);
 	FLAG_Z |= res;
 
-	m68ki_write_32(ea, res);
+	m68ki_write_32(state, ea, res);
 }
 
 
@@ -10394,7 +10394,7 @@ M68KMAKE_OP(tas, 8, ., d)
 M68KMAKE_OP(tas, 8, ., .)
 {
 	uint ea = M68KMAKE_GET_EA_AY_8;
-	uint dst = m68ki_read_8(ea);
+	uint dst = m68ki_read_8(state, ea);
 	uint allow_writeback;
 
 	FLAG_Z = dst;
@@ -10408,14 +10408,14 @@ M68KMAKE_OP(tas, 8, ., .)
        will be needed. */
 	allow_writeback = m68ki_tas_callback();
 
-	if (allow_writeback==1) m68ki_write_8(ea, dst | 0x80);
+	if (allow_writeback==1) m68ki_write_8(state, ea, dst | 0x80);
 }
 
 
 M68KMAKE_OP(trap, 0, ., .)
 {
 	/* Trap#n stacks exception frame type 0 */
-	m68ki_exception_trapN(EXCEPTION_TRAP_BASE + (REG_IR & 0xf));	/* HJB 990403 */
+	m68ki_exception_trapN(state, EXCEPTION_TRAP_BASE + (REG_IR & 0xf));	/* HJB 990403 */
 }
 
 
@@ -10423,10 +10423,10 @@ M68KMAKE_OP(trapt, 0, ., .)
 {
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
-		m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		m68ki_exception_trap(state, EXCEPTION_TRAPV);	/* HJB 990403 */
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10436,10 +10436,10 @@ M68KMAKE_OP(trapt, 16, ., .)
 	{
 	// TODO: review this... as mame is not using it...
         REG_PC += 2; // JFF else stackframe & return addresses are incorrect
-		m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		m68ki_exception_trap(state, EXCEPTION_TRAPV);	/* HJB 990403 */
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10449,10 +10449,10 @@ M68KMAKE_OP(trapt, 32, ., .)
 	{
 	// TODO: review this... as mame is not using it...
         REG_PC += 4; // JFF else stackframe & return addresses are incorrect
-		m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		m68ki_exception_trap(state, EXCEPTION_TRAPV);	/* HJB 990403 */
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10462,7 +10462,7 @@ M68KMAKE_OP(trapf, 0, ., .)
 	{
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10473,7 +10473,7 @@ M68KMAKE_OP(trapf, 16, ., .)
 		REG_PC += 2;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10484,7 +10484,7 @@ M68KMAKE_OP(trapf, 32, ., .)
 		REG_PC += 4;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10493,10 +10493,10 @@ M68KMAKE_OP(trapcc, 0, ., .)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		if(M68KMAKE_CC)
-			m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+			m68ki_exception_trap(state, EXCEPTION_TRAPV);	/* HJB 990403 */
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10508,13 +10508,13 @@ M68KMAKE_OP(trapcc, 16, ., .)
      	REG_PC += 2;  /* JFF increase before or 1) stackframe is incorrect 2) RTE address is wrong if trap is taken */
 		if(M68KMAKE_CC)
 		{
-			m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+			m68ki_exception_trap(state, EXCEPTION_TRAPV);	/* HJB 990403 */
 			return;
 		}
 
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10526,12 +10526,12 @@ M68KMAKE_OP(trapcc, 32, ., .)
 		REG_PC += 4;  /* JFF increase before or 1) stackframe is incorrect 2) RTE address is wrong if trap is taken */
 		if(M68KMAKE_CC)
 		{
-			m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+			m68ki_exception_trap(state, EXCEPTION_TRAPV);	/* HJB 990403 */
 			return;
 		}
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10541,7 +10541,7 @@ M68KMAKE_OP(trapv, 0, ., .)
 	{
 		return;
 	}
-	m68ki_exception_trap(EXCEPTION_TRAPV);  /* HJB 990403 */
+	m68ki_exception_trap(state, EXCEPTION_TRAPV);  /* HJB 990403 */
 }
 
 
@@ -10579,7 +10579,7 @@ M68KMAKE_OP(tst, 8, ., pcdi)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10595,7 +10595,7 @@ M68KMAKE_OP(tst, 8, ., pcix)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10611,7 +10611,7 @@ M68KMAKE_OP(tst, 8, ., i)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10638,7 +10638,7 @@ M68KMAKE_OP(tst, 16, ., a)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10665,7 +10665,7 @@ M68KMAKE_OP(tst, 16, ., pcdi)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10681,7 +10681,7 @@ M68KMAKE_OP(tst, 16, ., pcix)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10697,7 +10697,7 @@ M68KMAKE_OP(tst, 16, ., i)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10724,7 +10724,7 @@ M68KMAKE_OP(tst, 32, ., a)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10751,7 +10751,7 @@ M68KMAKE_OP(tst, 32, ., pcdi)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10767,7 +10767,7 @@ M68KMAKE_OP(tst, 32, ., pcix)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10783,13 +10783,13 @@ M68KMAKE_OP(tst, 32, ., i)
 		FLAG_C = CFLAG_CLEAR;
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
 M68KMAKE_OP(unlk, 32, ., a7)
 {
-	REG_A[7] = m68ki_read_32(REG_A[7]);
+	REG_A[7] = m68ki_read_32(state, REG_A[7]);
 }
 
 
@@ -10798,7 +10798,7 @@ M68KMAKE_OP(unlk, 32, ., .)
 	uint* r_dst = &AY;
 
 	REG_A[7] = *r_dst;
-	*r_dst = m68ki_pull_32();
+	*r_dst = m68ki_pull_32(state);
 }
 
 
@@ -10813,7 +10813,7 @@ M68KMAKE_OP(unpk, 16, rr, .)
 		*r_dst = MASK_OUT_BELOW_16(*r_dst) | (((((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state)) & 0xffff);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10827,12 +10827,12 @@ M68KMAKE_OP(unpk, 16, mm, ax7)
 
 		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_A7_PD_8();
-		m68ki_write_8(ea_dst, src & 0xff);
+		m68ki_write_8(state, ea_dst, src & 0xff);
 		ea_dst = EA_A7_PD_8();
-		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		m68ki_write_8(state, ea_dst, (src >> 8) & 0xff);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10846,12 +10846,12 @@ M68KMAKE_OP(unpk, 16, mm, ay7)
 
 		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_AX_PD_8();
-		m68ki_write_8(ea_dst, src & 0xff);
+		m68ki_write_8(state, ea_dst, src & 0xff);
 		ea_dst = EA_AX_PD_8();
-		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		m68ki_write_8(state, ea_dst, (src >> 8) & 0xff);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10864,12 +10864,12 @@ M68KMAKE_OP(unpk, 16, mm, axy7)
 
 		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_A7_PD_8();
-		m68ki_write_8(ea_dst, src & 0xff);
+		m68ki_write_8(state, ea_dst, src & 0xff);
 		ea_dst = EA_A7_PD_8();
-		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		m68ki_write_8(state, ea_dst, (src >> 8) & 0xff);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 
@@ -10883,12 +10883,12 @@ M68KMAKE_OP(unpk, 16, mm, .)
 
 		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16(state);
 		ea_dst = EA_AX_PD_8();
-		m68ki_write_8(ea_dst, src & 0xff);
+		m68ki_write_8(state, ea_dst, src & 0xff);
 		ea_dst = EA_AX_PD_8();
-		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		m68ki_write_8(state, ea_dst, (src >> 8) & 0xff);
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_illegal(state);
 }
 
 

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -6931,7 +6931,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x003:				/* TC */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_tc;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_tc;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6939,7 +6939,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x004:				/* ITT0 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_itt0;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_itt0;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6947,7 +6947,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x005:				/* ITT1 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_itt1;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_itt1;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6955,7 +6955,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x006:				/* DTT0 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_dtt0;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_dtt0;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6963,7 +6963,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x007:				/* DTT1 */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_dtt1;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_dtt1;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6971,7 +6971,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x805:				/* MMUSR */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_sr_040;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_sr_040;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6979,7 +6979,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x806:				/* URP */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_urp_aptr;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_urp_aptr;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -6987,7 +6987,7 @@ M68KMAKE_OP(movec, 32, cr, .)
 			case 0x807:				/* SRP */
 				if(CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					REG_DA[(word2 >> 12) & 15] = m68ki_cpu.mmu_srp_aptr;
+					REG_DA[(word2 >> 12) & 15] = state->mmu_srp_aptr;
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7090,15 +7090,15 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x003:			/* TC */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_tc = REG_DA[(word2 >> 12) & 15];
+					state->mmu_tc = REG_DA[(word2 >> 12) & 15];
 
-					if (m68ki_cpu.mmu_tc & 0x8000)
+					if (state->mmu_tc & 0x8000)
 					{
-						m68ki_cpu.pmmu_enabled = 1;
+						state->pmmu_enabled = 1;
 					}
 					else
 					{
-						m68ki_cpu.pmmu_enabled = 0;
+						state->pmmu_enabled = 0;
 					}
 					return;
 				}
@@ -7107,7 +7107,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x004:			/* ITT0 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_itt0 = REG_DA[(word2 >> 12) & 15];
+					state->mmu_itt0 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7115,7 +7115,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x005:			/* ITT1 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_itt1 = REG_DA[(word2 >> 12) & 15];
+					state->mmu_itt1 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7123,7 +7123,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x006:			/* DTT0 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_dtt0 = REG_DA[(word2 >> 12) & 15];
+					state->mmu_dtt0 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7131,7 +7131,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x007:			/* DTT1 */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_dtt1 = REG_DA[(word2 >> 12) & 15];
+					state->mmu_dtt1 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7139,7 +7139,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x805:			/* MMUSR */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_sr_040 = REG_DA[(word2 >> 12) & 15];
+					state->mmu_sr_040 = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7147,7 +7147,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x806:			/* URP */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_urp_aptr = REG_DA[(word2 >> 12) & 15];
+					state->mmu_urp_aptr = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);
@@ -7155,7 +7155,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 			case 0x807:			/* SRP */
 				if (CPU_TYPE_IS_040_PLUS(CPU_TYPE))
 				{
-					m68ki_cpu.mmu_srp_aptr = REG_DA[(word2 >> 12) & 15];
+					state->mmu_srp_aptr = REG_DA[(word2 >> 12) & 15];
 					return;
 				}
 				m68ki_exception_illegal(state);

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -1854,7 +1854,7 @@ M68KMAKE_OP(andi, 32, ., .)
 
 M68KMAKE_OP(andi, 16, toc, .)
 {
-	m68ki_set_ccr(m68ki_get_ccr() & OPER_I_8(state));
+	m68ki_set_ccr(state, m68ki_get_ccr(state) & OPER_I_8(state));
 }
 
 
@@ -2303,7 +2303,7 @@ M68KMAKE_OP(bcc, 8, ., .)
 	if(M68KMAKE_CC)
 	{
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+		m68ki_branch_8(state, MASK_OUT_ABOVE_8(REG_IR));
 		return;
 	}
 	USE_CYCLES(CYC_BCC_NOTAKE_B);
@@ -2317,7 +2317,7 @@ M68KMAKE_OP(bcc, 16, ., .)
 		uint offset = OPER_I_16(state);
 		REG_PC -= 2;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_branch_16(offset);
+		m68ki_branch_16(state, offset);
 		return;
 	}
 	REG_PC += 2;
@@ -2334,7 +2334,7 @@ M68KMAKE_OP(bcc, 32, ., .)
 			uint offset = OPER_I_32(state);
 			REG_PC -= 4;
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-			m68ki_branch_32(offset);
+			m68ki_branch_32(state, offset);
 			return;
 		}
 		REG_PC += 4;
@@ -2345,7 +2345,7 @@ M68KMAKE_OP(bcc, 32, ., .)
 		if(M68KMAKE_CC)
 		{
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-			m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+			m68ki_branch_8(state, MASK_OUT_ABOVE_8(REG_IR));
 			return;
 		}
 		USE_CYCLES(CYC_BCC_NOTAKE_B);
@@ -3180,7 +3180,7 @@ M68KMAKE_OP(bkpt, 0, ., .)
 M68KMAKE_OP(bra, 8, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+	m68ki_branch_8(state, MASK_OUT_ABOVE_8(REG_IR));
 // TODO: review this...
 //	if(REG_PC == REG_PPC)
 //		USE_ALL_CYCLES();
@@ -3192,7 +3192,7 @@ M68KMAKE_OP(bra, 16, ., .)
 	uint offset = OPER_I_16(state);
 	REG_PC -= 2;
 	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-	m68ki_branch_16(offset);
+	m68ki_branch_16(state, offset);
 // TODO: review this...
 //	if(REG_PC == REG_PPC)
 //		USE_ALL_CYCLES();
@@ -3206,7 +3206,7 @@ M68KMAKE_OP(bra, 32, ., .)
 		uint offset = OPER_I_32(state);
 		REG_PC -= 4;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_branch_32(offset);
+		m68ki_branch_32(state, offset);
 // TODO: review this...
 //		if(REG_PC == REG_PPC)
 //			USE_ALL_CYCLES();
@@ -3217,7 +3217,7 @@ M68KMAKE_OP(bra, 32, ., .)
 // TODO: review this...
 		m68ki_exception_illegal(state);
 //		m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-//		m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+//		m68ki_branch_8(state, MASK_OUT_ABOVE_8(REG_IR));
 //		if(REG_PC == REG_PPC)
 //			USE_ALL_CYCLES();
 	}
@@ -3270,7 +3270,7 @@ M68KMAKE_OP(bsr, 8, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 	m68ki_push_32(state, REG_PC);
-	m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+	m68ki_branch_8(state, MASK_OUT_ABOVE_8(REG_IR));
 }
 
 
@@ -3280,7 +3280,7 @@ M68KMAKE_OP(bsr, 16, ., .)
 	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 	m68ki_push_32(state, REG_PC);
 	REG_PC -= 2;
-	m68ki_branch_16(offset);
+	m68ki_branch_16(state, offset);
 }
 
 
@@ -3292,7 +3292,7 @@ M68KMAKE_OP(bsr, 32, ., .)
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		m68ki_push_32(state, REG_PC);
 		REG_PC -= 4;
-		m68ki_branch_32(offset);
+		m68ki_branch_32(state, offset);
 		return;
 	}
 	else
@@ -3301,7 +3301,7 @@ M68KMAKE_OP(bsr, 32, ., .)
 		m68ki_exception_illegal(state);
 //		m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 //		m68ki_push_32(state, REG_PC);
-//		m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+//		m68ki_branch_8(state, MASK_OUT_ABOVE_8(REG_IR));
 	}
 }
 
@@ -4514,7 +4514,7 @@ M68KMAKE_OP(dbf, 16, ., .)
 		uint offset = OPER_I_16(state);
 		REG_PC -= 2;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_branch_16(offset);
+		m68ki_branch_16(state, offset);
 		USE_CYCLES(CYC_DBCC_F_NOEXP);
 		return;
 	}
@@ -4536,7 +4536,7 @@ M68KMAKE_OP(dbcc, 16, ., .)
 			uint offset = OPER_I_16(state);
 			REG_PC -= 2;
 			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-			m68ki_branch_16(offset);
+			m68ki_branch_16(state, offset);
 			USE_CYCLES(CYC_DBCC_F_NOEXP);
 			return;
 		}
@@ -5251,7 +5251,7 @@ M68KMAKE_OP(eori, 32, ., .)
 
 M68KMAKE_OP(eori, 16, toc, .)
 {
-	m68ki_set_ccr(m68ki_get_ccr() ^ OPER_I_8(state));
+	m68ki_set_ccr(state, m68ki_get_ccr(state) ^ OPER_I_8(state));
 }
 
 
@@ -5349,7 +5349,7 @@ M68KMAKE_OP(illegal, 0, ., .)
 
 M68KMAKE_OP(jmp, 32, ., .)
 {
-	m68ki_jump(M68KMAKE_GET_EA_AY_32);
+	m68ki_jump(state, M68KMAKE_GET_EA_AY_32);
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 }
 
@@ -5359,7 +5359,7 @@ M68KMAKE_OP(jsr, 32, ., .)
 	uint ea = M68KMAKE_GET_EA_AY_32;
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 	m68ki_push_32(state, REG_PC);
-	m68ki_jump(ea);
+	m68ki_jump(state, ea);
 }
 
 
@@ -6774,7 +6774,7 @@ M68KMAKE_OP(move, 16, frc, d)
 {
 	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
 	{
-		DY = MASK_OUT_BELOW_16(DY) | m68ki_get_ccr();
+		DY = MASK_OUT_BELOW_16(DY) | m68ki_get_ccr(state);
 		return;
 	}
 	m68ki_exception_illegal(state);
@@ -6785,7 +6785,7 @@ M68KMAKE_OP(move, 16, frc, .)
 {
 	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
 	{
-		m68ki_write_16(state, M68KMAKE_GET_EA_AY_16, m68ki_get_ccr());
+		m68ki_write_16(state, M68KMAKE_GET_EA_AY_16, m68ki_get_ccr(state));
 		return;
 	}
 	m68ki_exception_illegal(state);
@@ -6794,13 +6794,13 @@ M68KMAKE_OP(move, 16, frc, .)
 
 M68KMAKE_OP(move, 16, toc, d)
 {
-	m68ki_set_ccr(DY);
+	m68ki_set_ccr(state, DY);
 }
 
 
 M68KMAKE_OP(move, 16, toc, .)
 {
-	m68ki_set_ccr(M68KMAKE_GET_OPER_AY_16);
+	m68ki_set_ccr(state, M68KMAKE_GET_OPER_AY_16);
 }
 
 
@@ -8404,7 +8404,7 @@ M68KMAKE_OP(ori, 32, ., .)
 
 M68KMAKE_OP(ori, 16, toc, .)
 {
-	m68ki_set_ccr(m68ki_get_ccr() | OPER_I_8(state));
+	m68ki_set_ccr(state, m68ki_get_ccr(state) | OPER_I_8(state));
 }
 
 
@@ -9336,7 +9336,7 @@ M68KMAKE_OP(rtd, 32, ., .)
 
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16(state)));
-		m68ki_jump(new_pc);
+		m68ki_jump(state, new_pc);
 		return;
 	}
 	m68ki_exception_illegal(state);
@@ -9358,7 +9358,7 @@ M68KMAKE_OP(rte, 32, ., .)
 		{
 			new_sr = m68ki_pull_16(state);
 			new_pc = m68ki_pull_32(state);
-			m68ki_jump(new_pc);
+			m68ki_jump(state, new_pc);
 			m68ki_set_sr(state, new_sr);
 
 			CPU_INSTR_MODE = INSTRUCTION_YES;
@@ -9375,7 +9375,7 @@ M68KMAKE_OP(rte, 32, ., .)
 				new_sr = m68ki_pull_16(state);
 				new_pc = m68ki_pull_32(state);
 				m68ki_fake_pull_16(state);	/* format word */
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9385,7 +9385,7 @@ M68KMAKE_OP(rte, 32, ., .)
 				new_sr = m68ki_pull_16(state);
 				new_pc = m68ki_pull_32(state);
 				m68ki_fake_pull_16(state);	/* format word */
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9420,7 +9420,7 @@ rte_loop:
 				new_sr = m68ki_pull_16(state);
 				new_pc = m68ki_pull_32(state);
 				m68ki_fake_pull_16(state);	/* format word */
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9436,7 +9436,7 @@ rte_loop:
 				new_pc = m68ki_pull_32(state);
 				m68ki_fake_pull_16(state);	/* format word */
 				m68ki_fake_pull_32(state);	/* address */
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9460,7 +9460,7 @@ rte_loop:
 				m68ki_fake_pull_32(state);   /* $30: pd1 */
 				m68ki_fake_pull_32(state);   /* $34: pd2 */
 				m68ki_fake_pull_32(state);   /* $38: pd3 */
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9479,7 +9479,7 @@ rte_loop:
 				m68ki_fake_pull_32(state);   /* $18: data output buffer */
 				m68ki_fake_pull_32(state);   /* $1c: internal registers */
 
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9514,7 +9514,7 @@ rte_loop:
 				m68ki_fake_pull_32(state);   /* $54:  */
 				m68ki_fake_pull_32(state);   /* $58:  */
 
-				m68ki_jump(new_pc);
+				m68ki_jump(state, new_pc);
 				m68ki_set_sr(state, new_sr);
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
@@ -9547,15 +9547,15 @@ M68KMAKE_OP(rtm, 32, ., .)
 M68KMAKE_OP(rtr, 32, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_set_ccr(m68ki_pull_16(state));
-	m68ki_jump(m68ki_pull_32(state));
+	m68ki_set_ccr(state, m68ki_pull_16(state));
+	m68ki_jump(state, m68ki_pull_32(state));
 }
 
 
 M68KMAKE_OP(rts, 32, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
-	m68ki_jump(m68ki_pull_32(state));
+	m68ki_jump(state, m68ki_pull_32(state));
 }
 
 

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -7040,7 +7040,7 @@ M68KMAKE_OP(movec, 32, rc, .)
 					}
 
 					if (REG_CACR & (M68K_CACR_CI | M68K_CACR_CEI)) {
-						m68ki_ic_clear();
+						m68ki_ic_clear(state);
 					}
 					return;
 				}

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -112,7 +112,9 @@ M68KMAKE_PROTOTYPE_FOOTER
 /* Build the opcode handler table */
 void m68ki_build_opcode_table(void);
 
-extern void (*m68ki_instruction_jump_table[0x10000])(void); /* opcode handler jump table */
+struct m68ki_cpu_core;
+
+extern void (*m68ki_instruction_jump_table[0x10000])(struct m68ki_cpu_core *state); /* opcode handler jump table */
 extern unsigned char m68ki_cycles[][0x10000];
 
 
@@ -136,13 +138,13 @@ M68KMAKE_TABLE_HEADER
 
 #define NUM_CPU_TYPES 5
 
-void  (*m68ki_instruction_jump_table[0x10000])(void); /* opcode handler jump table */
+void  (*m68ki_instruction_jump_table[0x10000])(m68ki_cpu_core *state); /* opcode handler jump table */
 unsigned char m68ki_cycles[NUM_CPU_TYPES][0x10000]; /* Cycles used by CPU type */
 
 /* This is used to generate the opcode handler jump table */
 typedef struct
 {
-	void (*opcode_handler)(void);        /* handler function */
+	void (*opcode_handler)(m68ki_cpu_core *state);        /* handler function */
 	unsigned int  mask;                  /* mask on opcode */
 	unsigned int  match;                 /* what to match after masking */
 	unsigned char cycles[NUM_CPU_TYPES]; /* cycles each cpu type takes */

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -958,7 +958,7 @@ uint m68k_get_address_mask() {
 
 /* Execute some instructions until we use up num_cycles clock cycles */
 /* ASG: removed per-instruction interrupt checks */
-int m68k_execute(int num_cycles)
+int m68k_execute(m68ki_cpu_core *state, int num_cycles)
 {
 	/* eat up any reset cycles */
 	if (RESET_CYCLES) {
@@ -1121,7 +1121,7 @@ void m68k_pulse_bus_error(void)
 }
 
 /* Pulse the RESET line on the CPU */
-void m68k_pulse_reset(void)
+void m68k_pulse_reset(m68ki_cpu_core *state)
 {
 	/* Disable the PMMU/HMMU on reset, if any */
 	m68ki_cpu.pmmu_enabled = 0;
@@ -1172,7 +1172,7 @@ void m68k_pulse_reset(void)
 	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		// clear instruction cache
-		m68ki_ic_clear();
+		m68ki_ic_clear(state);
 	}
 }
 

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -724,7 +724,8 @@ void m68k_set_reg(void *context, m68k_register_t regnum, unsigned int value)
 		case M68K_REG_CAAR:	REG_CAAR = MASK_OUT_ABOVE_32(value); return;
 		case M68K_REG_PPC:	REG_PPC = MASK_OUT_ABOVE_32(value); return;
 		case M68K_REG_IR:	REG_IR = MASK_OUT_ABOVE_16(value); return;
-		case M68K_REG_CPU_TYPE: m68k_set_cpu_type(value); return;
+		case M68K_REG_CPU_TYPE:
+			m68k_set_cpu_type(state, value); return;
 		default:			return;
 	}
 }
@@ -781,7 +782,7 @@ void m68k_set_instr_hook_callback(void  (*callback)(unsigned int pc))
 }
 
 /* Set the CPU type. */
-void m68k_set_cpu_type(unsigned int cpu_type)
+void m68k_set_cpu_type(struct m68ki_cpu_core *state, unsigned int cpu_type)
 {
 	switch(cpu_type)
 	{
@@ -804,7 +805,7 @@ void m68k_set_cpu_type(unsigned int cpu_type)
 			HAS_FPU          = 0;
 			return;
 		case M68K_CPU_TYPE_SCC68070:
-			m68k_set_cpu_type(M68K_CPU_TYPE_68010);
+			m68k_set_cpu_type(state, M68K_CPU_TYPE_68010);
 			CPU_ADDRESS_MASK = 0xffffffff;
 			CPU_TYPE         = CPU_TYPE_SCC070;
 			return;
@@ -983,7 +984,7 @@ int m68k_execute(m68ki_cpu_core *state, int num_cycles)
 	if(!CPU_STOPPED)
 	{
 		/* Return point if we had an address error */
-		m68ki_set_address_error_trap(); /* auto-disable (see m68kcpu.h) */
+		m68ki_set_address_error_trap(state); /* auto-disable (see m68kcpu.h) */
 
 #ifdef M68K_BUSERR_THING
 		m68ki_check_bus_error_trap();
@@ -1277,7 +1278,7 @@ uint m68ki_read_imm16_addr_slowpath(m68ki_cpu_core *state, uint32_t pc, address_
 	m68ki_cpu.mmu_tmp_fc = FLAG_S | FUNCTION_CODE_USER_PROGRAM;
 	m68ki_cpu.mmu_tmp_rw = 1;
 	m68ki_cpu.mmu_tmp_sz = M68K_SZ_WORD;
-	m68ki_check_address_error(REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(state, REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
 
 #if M68K_EMULATE_PREFETCH
 {

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -42,7 +42,6 @@ extern void m68040_fpu_op0(void);
 extern void m68040_fpu_op1(void);
 extern void m68851_mmu_ops();
 extern unsigned char m68ki_cycles[][0x10000];
-extern void (*m68ki_instruction_jump_table[0x10000])(void); /* opcode handler jump table */
 extern void m68ki_build_opcode_table(void);
 
 #include "m68kops.h"
@@ -1012,7 +1011,7 @@ int m68k_execute(int num_cycles)
 
 			/* Read an instruction and call its handler */
 			REG_IR = m68ki_read_imm_16();
-			m68ki_instruction_jump_table[REG_IR]();
+			m68ki_instruction_jump_table[REG_IR](&m68ki_cpu);
 			USE_CYCLES(CYC_INSTRUCTION[REG_IR]);
 
 			/* Trace m68k_exception, if necessary */

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -337,66 +337,66 @@ typedef uint32 uint64;
 /* ------------------------------ CPU Access ------------------------------ */
 
 /* Access the CPU registers */
-#define CPU_TYPE         m68ki_cpu.cpu_type
+#define CPU_TYPE         state->cpu_type
 
-#define REG_DA           m68ki_cpu.dar /* easy access to data and address regs */
-#define REG_DA_SAVE      m68ki_cpu.dar_save
-#define REG_D            m68ki_cpu.dar
-#define REG_A            (m68ki_cpu.dar+8)
-#define REG_PPC          m68ki_cpu.ppc
-#define REG_PC           m68ki_cpu.pc
-#define REG_SP_BASE      m68ki_cpu.sp
-#define REG_USP          m68ki_cpu.sp[0]
-#define REG_ISP          m68ki_cpu.sp[4]
-#define REG_MSP          m68ki_cpu.sp[6]
-#define REG_SP           m68ki_cpu.dar[15]
-#define REG_VBR          m68ki_cpu.vbr
-#define REG_SFC          m68ki_cpu.sfc
-#define REG_DFC          m68ki_cpu.dfc
-#define REG_CACR         m68ki_cpu.cacr
-#define REG_CAAR         m68ki_cpu.caar
-#define REG_IR           m68ki_cpu.ir
+#define REG_DA           state->dar /* easy access to data and address regs */
+#define REG_DA_SAVE      state->dar_save
+#define REG_D            state->dar
+#define REG_A            (state->dar+8)
+#define REG_PPC          state->ppc
+#define REG_PC           state->pc
+#define REG_SP_BASE      state->sp
+#define REG_USP          state->sp[0]
+#define REG_ISP          state->sp[4]
+#define REG_MSP          state->sp[6]
+#define REG_SP           state->dar[15]
+#define REG_VBR          state->vbr
+#define REG_SFC          state->sfc
+#define REG_DFC          state->dfc
+#define REG_CACR         state->cacr
+#define REG_CAAR         state->caar
+#define REG_IR           state->ir
 
-#define REG_FP           m68ki_cpu.fpr
-#define REG_FPCR         m68ki_cpu.fpcr
-#define REG_FPSR         m68ki_cpu.fpsr
-#define REG_FPIAR        m68ki_cpu.fpiar
+#define REG_FP           state->fpr
+#define REG_FPCR         state->fpcr
+#define REG_FPSR         state->fpsr
+#define REG_FPIAR        state->fpiar
 
-#define FLAG_T1          m68ki_cpu.t1_flag
-#define FLAG_T0          m68ki_cpu.t0_flag
-#define FLAG_S           m68ki_cpu.s_flag
-#define FLAG_M           m68ki_cpu.m_flag
-#define FLAG_X           m68ki_cpu.x_flag
-#define FLAG_N           m68ki_cpu.n_flag
-#define FLAG_Z           m68ki_cpu.not_z_flag
-#define FLAG_V           m68ki_cpu.v_flag
-#define FLAG_C           m68ki_cpu.c_flag
-#define FLAG_INT_MASK    m68ki_cpu.int_mask
+#define FLAG_T1          state->t1_flag
+#define FLAG_T0          state->t0_flag
+#define FLAG_S           state->s_flag
+#define FLAG_M           state->m_flag
+#define FLAG_X           state->x_flag
+#define FLAG_N           state->n_flag
+#define FLAG_Z           state->not_z_flag
+#define FLAG_V           state->v_flag
+#define FLAG_C           state->c_flag
+#define FLAG_INT_MASK    state->int_mask
 
 #define CPU_INT_LEVEL    m68ki_cpu.int_level /* ASG: changed from CPU_INTS_PENDING */
 #define CPU_STOPPED      m68ki_cpu.stopped
-#define CPU_PREF_ADDR    m68ki_cpu.pref_addr
-#define CPU_PREF_DATA    m68ki_cpu.pref_data
-#define CPU_ADDRESS_MASK m68ki_cpu.address_mask
-#define CPU_SR_MASK      m68ki_cpu.sr_mask
-#define CPU_INSTR_MODE   m68ki_cpu.instr_mode
-#define CPU_RUN_MODE     m68ki_cpu.run_mode
+#define CPU_PREF_ADDR    state->pref_addr
+#define CPU_PREF_DATA    state->pref_data
+#define CPU_ADDRESS_MASK state->address_mask
+#define CPU_SR_MASK      state->sr_mask
+#define CPU_INSTR_MODE   state->instr_mode
+#define CPU_RUN_MODE     state->run_mode
 
-#define CYC_INSTRUCTION  m68ki_cpu.cyc_instruction
-#define CYC_EXCEPTION    m68ki_cpu.cyc_exception
-#define CYC_BCC_NOTAKE_B m68ki_cpu.cyc_bcc_notake_b
-#define CYC_BCC_NOTAKE_W m68ki_cpu.cyc_bcc_notake_w
-#define CYC_DBCC_F_NOEXP m68ki_cpu.cyc_dbcc_f_noexp
-#define CYC_DBCC_F_EXP   m68ki_cpu.cyc_dbcc_f_exp
-#define CYC_SCC_R_TRUE   m68ki_cpu.cyc_scc_r_true
-#define CYC_MOVEM_W      m68ki_cpu.cyc_movem_w
-#define CYC_MOVEM_L      m68ki_cpu.cyc_movem_l
-#define CYC_SHIFT        m68ki_cpu.cyc_shift
-#define CYC_RESET        m68ki_cpu.cyc_reset
-#define HAS_PMMU         m68ki_cpu.has_pmmu
-#define HAS_FPU          m68ki_cpu.has_fpu
-#define PMMU_ENABLED     m68ki_cpu.pmmu_enabled
-#define RESET_CYCLES     m68ki_cpu.reset_cycles
+#define CYC_INSTRUCTION  state->cyc_instruction
+#define CYC_EXCEPTION    state->cyc_exception
+#define CYC_BCC_NOTAKE_B state->cyc_bcc_notake_b
+#define CYC_BCC_NOTAKE_W state->cyc_bcc_notake_w
+#define CYC_DBCC_F_NOEXP state->cyc_dbcc_f_noexp
+#define CYC_DBCC_F_EXP   state->cyc_dbcc_f_exp
+#define CYC_SCC_R_TRUE   state->cyc_scc_r_true
+#define CYC_MOVEM_W      state->cyc_movem_w
+#define CYC_MOVEM_L      state->cyc_movem_l
+#define CYC_SHIFT        state->cyc_shift
+#define CYC_RESET        state->cyc_reset
+#define HAS_PMMU         state->has_pmmu
+#define HAS_FPU          state->has_fpu
+#define PMMU_ENABLED     state->pmmu_enabled
+#define RESET_CYCLES     state->reset_cycles
 
 
 #define CALLBACK_INT_ACK      m68ki_cpu.int_ack_callback
@@ -619,10 +619,10 @@ typedef uint32 uint64;
 /* sigjmp() on Mac OS X and *BSD in general saves signal contexts and is super-slow, use sigsetjmp() to tell it not to */
 #ifdef _BSD_SETJMP_H
 extern sigjmp_buf m68ki_aerr_trap;
-#define m68ki_set_address_error_trap(m68k) \
+#define m68ki_set_address_error_trap(state) \
 	if(sigsetjmp(m68ki_aerr_trap, 0) != 0) \
 	{ \
-		m68ki_exception_address_error(m68k); \
+		m68ki_exception_address_error(state); \
 		if(CPU_STOPPED) \
 		{ \
 			if (m68ki_remaining_cycles > 0) \
@@ -631,7 +631,7 @@ extern sigjmp_buf m68ki_aerr_trap;
 		} \
 	}
 
-#define m68ki_check_address_error(ADDR, WRITE_MODE, FC) \
+#define m68ki_check_address_error(state, ADDR, WRITE_MODE, FC) \
 	if((ADDR)&1) \
 	{ \
 		m68ki_aerr_address = ADDR; \
@@ -641,7 +641,7 @@ extern sigjmp_buf m68ki_aerr_trap;
 	}
 #else
 extern jmp_buf m68ki_aerr_trap;
-	#define m68ki_set_address_error_trap() \
+	#define m68ki_set_address_error_trap(state) \
 		if(setjmp(m68ki_aerr_trap) != 0) \
 		{ \
 			m68ki_exception_address_error(); \
@@ -659,7 +659,7 @@ extern jmp_buf m68ki_aerr_trap;
 			} \
 		}
 
-	#define m68ki_check_address_error(ADDR, WRITE_MODE, FC) \
+	#define m68ki_check_address_error(state, ADDR, WRITE_MODE, FC) \
 		if((ADDR)&1) \
 		{ \
 			m68ki_aerr_address = ADDR; \
@@ -670,15 +670,15 @@ extern jmp_buf m68ki_aerr_trap;
 #endif
 	#define m68ki_bus_error(ADDR,WRITE_MODE) m68ki_aerr_address=ADDR;m68ki_aerr_write_mode=WRITE_MODE;m68ki_exception_bus_error()
 
-	#define m68ki_check_address_error_010_less(ADDR, WRITE_MODE, FC) \
+	#define m68ki_check_address_error_010_less(state, ADDR, WRITE_MODE, FC) \
 		if (CPU_TYPE_IS_010_LESS(CPU_TYPE)) \
 		{ \
-			m68ki_check_address_error(ADDR, WRITE_MODE, FC) \
+			m68ki_check_address_error(state, ADDR, WRITE_MODE, FC) \
 		}
 #else
-	#define m68ki_set_address_error_trap()
-	#define m68ki_check_address_error(ADDR, WRITE_MODE, FC)
-	#define m68ki_check_address_error_010_less(ADDR, WRITE_MODE, FC)
+	#define m68ki_set_address_error_trap(state)
+	#define m68ki_check_address_error(state, ADDR, WRITE_MODE, FC)
+	#define m68ki_check_address_error_010_less(state, ADDR, WRITE_MODE, FC)
 #endif /* M68K_ADDRESS_ERROR */
 
 /* Logging */
@@ -1103,7 +1103,7 @@ inline void m68ki_ic_clear(m68ki_cpu_core *state)
 {
 	int i;
 	for (i=0; i< M68K_IC_SIZE; i++) {
-		m68ki_cpu.ic_address[i] = ~0;
+		state->ic_address[i] = ~0;
 	}
 }
 
@@ -1113,19 +1113,19 @@ extern uint32 pmmu_translate_addr(m68ki_cpu_core *state, uint32 addr_in, uint16 
 
 static inline uint32 m68ki_ic_readimm16(m68ki_cpu_core *state, uint32 address)
 {
-	if (m68ki_cpu.cacr & M68K_CACR_EI)
+	if (state->cacr & M68K_CACR_EI)
 	{
 		// 68020 series I-cache (MC68020 User's Manual, Section 4 - On-Chip Cache Memory)
 		if (CPU_TYPE & (CPU_TYPE_EC020 | CPU_TYPE_020))
 		{
-			uint32 tag = (address >> 8) | (m68ki_cpu.s_flag ? 0x1000000 : 0);
+			uint32 tag = (address >> 8) | (state->s_flag ? 0x1000000 : 0);
 			int idx = (address >> 2) & 0x3f;    // 1-of-64 select
 
 			// do a cache fill if the line is invalid or the tags don't match
-			if ((!m68ki_cpu.ic_valid[idx]) || (m68ki_cpu.ic_address[idx] != tag))
+			if ((!state->ic_valid[idx]) || (state->ic_address[idx] != tag))
 			{
 				// if the cache is frozen, don't update it
-				if (m68ki_cpu.cacr & M68K_CACR_FI)
+				if (state->cacr & M68K_CACR_FI)
 				{
 					return m68k_read_immediate_16(state, address);
 				}
@@ -1135,11 +1135,11 @@ static inline uint32 m68ki_ic_readimm16(m68ki_cpu_core *state, uint32 address)
 				//printf("m68k: doing cache fill at %08x (tag %08x idx %d)\n", address, tag, idx);
 
 				// if no buserror occurred, validate the tag
-				if (!m68ki_cpu.mmu_tmp_buserror_occurred)
+				if (!state->mmu_tmp_buserror_occurred)
 				{
-					m68ki_cpu.ic_address[idx] = tag;
-					m68ki_cpu.ic_data[idx] = data;
-					m68ki_cpu.ic_valid[idx] = 1;
+					state->ic_address[idx] = tag;
+					state->ic_data[idx] = data;
+					state->ic_valid[idx] = 1;
 				}
 				else
 				{
@@ -1151,11 +1151,11 @@ static inline uint32 m68ki_ic_readimm16(m68ki_cpu_core *state, uint32 address)
 			// a hit or because we just filled it.
 			if (address & 2)
 			{
-				return m68ki_cpu.ic_data[idx] & 0xffff;
+				return state->ic_data[idx] & 0xffff;
 			}
 			else
 			{
-				return m68ki_cpu.ic_data[idx] >> 16;
+				return state->ic_data[idx] >> 16;
 			}
 		}
 	}
@@ -1173,7 +1173,7 @@ static inline uint m68ki_read_imm_16(m68ki_cpu_core *state)
 {
 	uint32_t pc = REG_PC;
 
-	address_translation_cache *cache = &m68ki_cpu.code_translation_cache;
+	address_translation_cache *cache = &state->code_translation_cache;
 	if(pc >= cache->lower && pc < cache->upper)
 	{
 		REG_PC += 2;
@@ -1197,10 +1197,10 @@ static inline uint m68ki_read_imm_32(m68ki_cpu_core *state)
 #endif
 #endif
 	uint32_t address = ADDRESS_68K(REG_PC);
-	for (int i = 0; i < m68ki_cpu.read_ranges; i++) {
-		if(address >= m68ki_cpu.read_addr[i] && address < m68ki_cpu.read_upper[i]) {
+	for (int i = 0; i < state->read_ranges; i++) {
+		if(address >= state->read_addr[i] && address < state->read_upper[i]) {
 			REG_PC += 4;
-			return be32toh(((unsigned int *)(m68ki_cpu.read_data[i] + (address - m68ki_cpu.read_addr[i])))[0]);
+			return be32toh(((unsigned int *)(state->read_data[i] + (address - state->read_addr[i])))[0]);
 		}
 	}
 
@@ -1208,10 +1208,10 @@ static inline uint m68ki_read_imm_32(m68ki_cpu_core *state)
 	uint temp_val;
 
 	m68ki_set_fc(FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = FLAG_S | FUNCTION_CODE_USER_PROGRAM;
-	m68ki_cpu.mmu_tmp_rw = 1;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_LONG;
-	m68ki_check_address_error(REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	state->mmu_tmp_fc = FLAG_S | FUNCTION_CODE_USER_PROGRAM;
+	state->mmu_tmp_rw = 1;
+	state->mmu_tmp_sz = M68K_SZ_LONG;
+	m68ki_check_address_error(state, REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
 
 	if(REG_PC != CPU_PREF_ADDR)
 	{
@@ -1226,7 +1226,7 @@ static inline uint m68ki_read_imm_32(m68ki_cpu_core *state)
 	temp_val = MASK_OUT_ABOVE_32((temp_val << 16) | MASK_OUT_ABOVE_16(CPU_PREF_DATA));
 	REG_PC += 2;
 	CPU_PREF_DATA = m68ki_ic_readimm16(state, REG_PC);
-	CPU_PREF_ADDR = m68ki_cpu.mmu_tmp_buserror_occurred ? ((uint32)~0) : REG_PC;
+	CPU_PREF_ADDR = state->mmu_tmp_buserror_occurred ? ((uint32)~0) : REG_PC;
 
 	return temp_val;
 #else
@@ -1249,18 +1249,18 @@ static inline uint m68ki_read_8_fc(m68ki_cpu_core *state, uint address, uint fc)
 {
 	(void)fc;
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 1;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_BYTE;
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 1;
+	state->mmu_tmp_sz = M68K_SZ_BYTE;
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
 	    address = pmmu_translate_addr(address,1);
 #endif
 
-	for (int i = 0; i < m68ki_cpu.read_ranges; i++) {
-		if(address >= m68ki_cpu.read_addr[i] && address < m68ki_cpu.read_upper[i]) {
-			return m68ki_cpu.read_data[i][address - m68ki_cpu.read_addr[i]];
+	for (int i = 0; i < state->read_ranges; i++) {
+		if(address >= state->read_addr[i] && address < state->read_upper[i]) {
+			return state->read_data[i][address - state->read_addr[i]];
 		}
 	}
 
@@ -1269,19 +1269,19 @@ static inline uint m68ki_read_8_fc(m68ki_cpu_core *state, uint address, uint fc)
 static inline uint m68ki_read_16_fc(m68ki_cpu_core *state, uint address, uint fc)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 1;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_WORD;
-	m68ki_check_address_error_010_less(address, MODE_READ, fc); /* auto-disable (see m68kcpu.h) */
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 1;
+	state->mmu_tmp_sz = M68K_SZ_WORD;
+	m68ki_check_address_error_010_less(state, address, MODE_READ, fc); /* auto-disable (see m68kcpu.h) */
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
 	    address = pmmu_translate_addr(state, address,1);
 #endif
 
-	for (int i = 0; i < m68ki_cpu.read_ranges; i++) {
-		if(address >= m68ki_cpu.read_addr[i] && address < m68ki_cpu.read_upper[i]) {
-			return be16toh(((unsigned short *)(m68ki_cpu.read_data[i] + (address - m68ki_cpu.read_addr[i])))[0]);
+	for (int i = 0; i < state->read_ranges; i++) {
+		if(address >= state->read_addr[i] && address < state->read_upper[i]) {
+			return be16toh(((unsigned short *)(state->read_data[i] + (address - state->read_addr[i])))[0]);
 		}
 	}
 
@@ -1290,19 +1290,19 @@ static inline uint m68ki_read_16_fc(m68ki_cpu_core *state, uint address, uint fc
 static inline uint m68ki_read_32_fc(m68ki_cpu_core *state, uint address, uint fc)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 1;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_LONG;
-	m68ki_check_address_error_010_less(address, MODE_READ, fc); /* auto-disable (see m68kcpu.h) */
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 1;
+	state->mmu_tmp_sz = M68K_SZ_LONG;
+	m68ki_check_address_error_010_less(state, address, MODE_READ, fc); /* auto-disable (see m68kcpu.h) */
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
 	    address = pmmu_translate_addr(state, address,1);
 #endif
 
-	for (int i = 0; i < m68ki_cpu.read_ranges; i++) {
-		if(address >= m68ki_cpu.read_addr[i] && address < m68ki_cpu.read_upper[i]) {
-			return be32toh(((unsigned int *)(m68ki_cpu.read_data[i] + (address - m68ki_cpu.read_addr[i])))[0]);
+	for (int i = 0; i < state->read_ranges; i++) {
+		if(address >= state->read_addr[i] && address < state->read_upper[i]) {
+			return be32toh(((unsigned int *)(state->read_data[i] + (address - state->read_addr[i])))[0]);
 		}
 	}
 
@@ -1312,18 +1312,18 @@ static inline uint m68ki_read_32_fc(m68ki_cpu_core *state, uint address, uint fc
 static inline void m68ki_write_8_fc(m68ki_cpu_core *state, uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 0;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_BYTE;
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 0;
+	state->mmu_tmp_sz = M68K_SZ_BYTE;
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
 	    address = pmmu_translate_addr(address,0);
 #endif
 
-	for (int i = 0; i < m68ki_cpu.write_ranges; i++) {
-		if(address >= m68ki_cpu.write_addr[i] && address < m68ki_cpu.write_upper[i]) {
-			m68ki_cpu.write_data[i][address - m68ki_cpu.write_addr[i]] = (unsigned char)value;
+	for (int i = 0; i < state->write_ranges; i++) {
+		if(address >= state->write_addr[i] && address < state->write_upper[i]) {
+			state->write_data[i][address - state->write_addr[i]] = (unsigned char)value;
 			return;
 		}
 	}
@@ -1333,19 +1333,19 @@ static inline void m68ki_write_8_fc(m68ki_cpu_core *state, uint address, uint fc
 static inline void m68ki_write_16_fc(m68ki_cpu_core *state, uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 0;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_WORD;
-	m68ki_check_address_error_010_less(address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 0;
+	state->mmu_tmp_sz = M68K_SZ_WORD;
+	m68ki_check_address_error_010_less(state, address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
 	    address = pmmu_translate_addr(address,0);
 #endif
 
-	for (int i = 0; i < m68ki_cpu.write_ranges; i++) {
-		if(address >= m68ki_cpu.write_addr[i] && address < m68ki_cpu.write_upper[i]) {
-			((short *)(m68ki_cpu.write_data[i] + (address - m68ki_cpu.write_addr[i])))[0] = htobe16(value);
+	for (int i = 0; i < state->write_ranges; i++) {
+		if(address >= state->write_addr[i] && address < state->write_upper[i]) {
+			((short *)(state->write_data[i] + (address - state->write_addr[i])))[0] = htobe16(value);
 			return;
 		}
 	}
@@ -1355,19 +1355,19 @@ static inline void m68ki_write_16_fc(m68ki_cpu_core *state, uint address, uint f
 static inline void m68ki_write_32_fc(m68ki_cpu_core *state, uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 0;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_LONG;
-	m68ki_check_address_error_010_less(address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 0;
+	state->mmu_tmp_sz = M68K_SZ_LONG;
+	m68ki_check_address_error_010_less(state, address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
 	    address = pmmu_translate_addr(address,0);
 #endif
 
-	for (int i = 0; i < m68ki_cpu.write_ranges; i++) {
-		if(address >= m68ki_cpu.write_addr[i] && address < m68ki_cpu.write_upper[i]) {
-			((int *)(m68ki_cpu.write_data[i] + (address - m68ki_cpu.write_addr[i])))[0] = htobe32(value);
+	for (int i = 0; i < state->write_ranges; i++) {
+		if(address >= state->write_addr[i] && address < state->write_upper[i]) {
+			((int *)(state->write_data[i] + (address - state->write_addr[i])))[0] = htobe32(value);
 			return;
 		}
 	}
@@ -1384,10 +1384,10 @@ static inline void m68ki_write_32_fc(m68ki_cpu_core *state, uint address, uint f
 static inline void m68ki_write_32_pd_fc(uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
-	m68ki_cpu.mmu_tmp_fc = fc;
-	m68ki_cpu.mmu_tmp_rw = 0;
-	m68ki_cpu.mmu_tmp_sz = M68K_SZ_LONG;
-	m68ki_check_address_error_010_less(address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
+	state->mmu_tmp_fc = fc;
+	state->mmu_tmp_rw = 0;
+	state->mmu_tmp_sz = M68K_SZ_LONG;
+	m68ki_check_address_error_010_less(state, address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
@@ -1898,9 +1898,9 @@ static inline void m68ki_stack_frame_1000(m68ki_cpu_core *state, uint pc, uint s
  */
 static inline void m68ki_stack_frame_1010(m68ki_cpu_core *state, uint sr, uint vector, uint pc, uint fault_address)
 {
-	int orig_rw = m68ki_cpu.mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
-	int orig_fc = m68ki_cpu.mmu_tmp_buserror_fc;
-	int orig_sz = m68ki_cpu.mmu_tmp_buserror_sz;
+	int orig_rw = state->mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
+	int orig_fc = state->mmu_tmp_buserror_fc;
+	int orig_sz = state->mmu_tmp_buserror_sz;
 
 	/* INTERNAL REGISTER */
 	m68ki_push_16(state, 0);
@@ -1951,9 +1951,9 @@ static inline void m68ki_stack_frame_1010(m68ki_cpu_core *state, uint sr, uint v
  */
 static inline void m68ki_stack_frame_1011(m68ki_cpu_core *state, uint sr, uint vector, uint pc, uint fault_address)
 {
-	int orig_rw = m68ki_cpu.mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
-	int orig_fc = m68ki_cpu.mmu_tmp_buserror_fc;
-	int orig_sz = m68ki_cpu.mmu_tmp_buserror_sz;
+	int orig_rw = state->mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
+	int orig_fc = state->mmu_tmp_buserror_fc;
+	int orig_sz = state->mmu_tmp_buserror_sz;
 	/* INTERNAL REGISTERS (18 words) */
 	m68ki_push_32(state, 0);
 	m68ki_push_32(state, 0);
@@ -2026,8 +2026,8 @@ static inline void m68ki_stack_frame_1011(m68ki_cpu_core *state, uint sr, uint v
 static inline void
 m68ki_stack_frame_0111(m68ki_cpu_core *state, uint sr, uint vector, uint pc, uint fault_address, uint8 in_mmu)
 {
-	int orig_rw = m68ki_cpu.mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
-	int orig_fc = m68ki_cpu.mmu_tmp_buserror_fc;
+	int orig_rw = state->mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
+	int orig_fc = state->mmu_tmp_buserror_fc;
 
 	/* INTERNAL REGISTERS (18 words) */
 	m68ki_push_32(state, 0);
@@ -2282,18 +2282,18 @@ static inline void m68ki_exception_address_error(m68ki_cpu_core *state)
 		/* only the 68010 throws this unique type-1000 frame */
 		m68ki_stack_frame_1000(state, REG_PPC, sr, EXCEPTION_BUS_ERROR);
 	}
-	else if (m68ki_cpu.mmu_tmp_buserror_address == REG_PPC)
+	else if (state->mmu_tmp_buserror_address == REG_PPC)
 	{
-		m68ki_stack_frame_1010(state, sr, EXCEPTION_BUS_ERROR, REG_PPC, m68ki_cpu.mmu_tmp_buserror_address);
+		m68ki_stack_frame_1010(state, sr, EXCEPTION_BUS_ERROR, REG_PPC, state->mmu_tmp_buserror_address);
 	}
 	else
 	{
-		m68ki_stack_frame_1011(state, sr, EXCEPTION_BUS_ERROR, REG_PPC, m68ki_cpu.mmu_tmp_buserror_address);
+		m68ki_stack_frame_1011(state, sr, EXCEPTION_BUS_ERROR, REG_PPC, state->mmu_tmp_buserror_address);
 	}
 
 	m68ki_jump_vector(state, EXCEPTION_ADDRESS_ERROR);
 
-	m68ki_cpu.run_mode = RUN_MODE_BERR_AERR_RESET;
+	state->run_mode = RUN_MODE_BERR_AERR_RESET;
 
 	/* Use up some clock cycles. Note that we don't need to undo the
 	instruction's cycles here as we've longjmp:ed directly from the
@@ -2379,9 +2379,9 @@ static inline void m68ki_exception_interrupt(m68ki_cpu_core *state, uint int_lev
 /* ASG: Check for interrupts */
 static inline void m68ki_check_interrupts(m68ki_cpu_core *state)
 {
-	if(m68ki_cpu.nmi_pending)
+	if(state->nmi_pending)
 	{
-		m68ki_cpu.nmi_pending = FALSE;
+		state->nmi_pending = FALSE;
 		m68ki_exception_interrupt(state, 7);
 	}
 	else if(CPU_INT_LEVEL > FLAG_INT_MASK)

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -473,12 +473,12 @@ typedef uint32 uint64;
 
 
 #if !M68K_SEPARATE_READS
-#define m68k_read_immediate_16(A) m68ki_read_program_16(A)
-#define m68k_read_immediate_32(A) m68ki_read_program_32(A)
+#define m68k_read_immediate_16(state, A) m68ki_read_program_16(state, A)
+#define m68k_read_immediate_32(state, A) m68ki_read_program_32(state, A)
 
-#define m68k_read_pcrelative_8(A) m68ki_read_program_8(A)
-#define m68k_read_pcrelative_16(A) m68ki_read_program_16(A)
-#define m68k_read_pcrelative_32(A) m68ki_read_program_32(A)
+#define m68k_read_pcrelative_8(state, A) m68ki_read_program_8(state, A)
+#define m68k_read_pcrelative_16(state, A) m68ki_read_program_16(state, A)
+#define m68k_read_pcrelative_32(state, A) m68ki_read_program_32(state, A)
 #endif /* M68K_SEPARATE_READS */
 
 
@@ -895,35 +895,35 @@ extern jmp_buf m68ki_aerr_trap;
 /* ----------------------------- Read / Write ----------------------------- */
 
 /* Read from the current address space */
-#define m68ki_read_8(A)  m68ki_read_8_fc (A, FLAG_S | m68ki_get_address_space())
-#define m68ki_read_16(A) m68ki_read_16_fc(A, FLAG_S | m68ki_get_address_space())
-#define m68ki_read_32(A) m68ki_read_32_fc(A, FLAG_S | m68ki_get_address_space())
+#define m68ki_read_8(state, A)  m68ki_read_8_fc (state, A, FLAG_S | m68ki_get_address_space())
+#define m68ki_read_16(state, A) m68ki_read_16_fc(state, A, FLAG_S | m68ki_get_address_space())
+#define m68ki_read_32(state, A) m68ki_read_32_fc(state, A, FLAG_S | m68ki_get_address_space())
 
 /* Write to the current data space */
-#define m68ki_write_8(A, V)  m68ki_write_8_fc (A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
-#define m68ki_write_16(A, V) m68ki_write_16_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
-#define m68ki_write_32(A, V) m68ki_write_32_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#define m68ki_write_8(state, A, V)  m68ki_write_8_fc (state, A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#define m68ki_write_16(state, A, V) m68ki_write_16_fc(state, A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#define m68ki_write_32(state, A, V) m68ki_write_32_fc(state, A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
 
 #if M68K_SIMULATE_PD_WRITES
 #define m68ki_write_32_pd(A, V) m68ki_write_32_pd_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
 #else
-#define m68ki_write_32_pd(A, V) m68ki_write_32_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#define m68ki_write_32_pd(state, A, V) m68ki_write_32_fc(state, A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
 #endif
 
 /* Map PC-relative reads */
-#define m68ki_read_pcrel_8(A) m68k_read_pcrelative_8(A)
-#define m68ki_read_pcrel_16(A) m68k_read_pcrelative_16(A)
-#define m68ki_read_pcrel_32(A) m68k_read_pcrelative_32(A)
+#define m68ki_read_pcrel_8(state, A) m68k_read_pcrelative_8(state, A)
+#define m68ki_read_pcrel_16(state, A) m68k_read_pcrelative_16(state, A)
+#define m68ki_read_pcrel_32(state, A) m68k_read_pcrelative_32(state, A)
 
 /* Read from the program space */
-#define m68ki_read_program_8(A) 	m68ki_read_8_fc(A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
-#define m68ki_read_program_16(A) 	m68ki_read_16_fc(A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
-#define m68ki_read_program_32(A) 	m68ki_read_32_fc(A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
+#define m68ki_read_program_8(state, A) 	m68ki_read_8_fc(state, A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
+#define m68ki_read_program_16(state, A) 	m68ki_read_16_fc(state, A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
+#define m68ki_read_program_32(state, A) 	m68ki_read_32_fc(state, A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
 
 /* Read from the data space */
-#define m68ki_read_data_8(A) 	m68ki_read_8_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA)
-#define m68ki_read_data_16(A) 	m68ki_read_16_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA)
-#define m68ki_read_data_32(A) 	m68ki_read_32_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA)
+#define m68ki_read_data_8(state, A) 	m68ki_read_8_fc(state, A, FLAG_S | FUNCTION_CODE_USER_DATA)
+#define m68ki_read_data_16(state, A) 	m68ki_read_16_fc(state, A, FLAG_S | FUNCTION_CODE_USER_DATA)
+#define m68ki_read_data_32(state, A) 	m68ki_read_32_fc(state, A, FLAG_S | FUNCTION_CODE_USER_DATA)
 
 
 
@@ -1082,8 +1082,8 @@ extern uint           m68ki_aerr_write_mode;
 extern uint           m68ki_aerr_fc;
 
 /* Forward declarations to keep some of the macros happy */
-static inline uint m68ki_read_16_fc (uint address, uint fc);
-static inline uint m68ki_read_32_fc (uint address, uint fc);
+static inline uint m68ki_read_16_fc(m68ki_cpu_core *state, uint address, uint fc);
+static inline uint m68ki_read_32_fc(m68ki_cpu_core *state, uint address, uint fc);
 static inline uint m68ki_get_ea_ix(m68ki_cpu_core *state, uint An);
 static inline void m68ki_check_interrupts(m68ki_cpu_core *state);            /* ASG: check for interrupts */
 
@@ -1111,7 +1111,7 @@ extern uint32 pmmu_translate_addr(m68ki_cpu_core *state, uint32 addr_in, uint16 
 
 // read immediate word using the instruction cache
 
-static inline uint32 m68ki_ic_readimm16(uint32 address)
+static inline uint32 m68ki_ic_readimm16(m68ki_cpu_core *state, uint32 address)
 {
 	if (m68ki_cpu.cacr & M68K_CACR_EI)
 	{
@@ -1127,10 +1127,10 @@ static inline uint32 m68ki_ic_readimm16(uint32 address)
 				// if the cache is frozen, don't update it
 				if (m68ki_cpu.cacr & M68K_CACR_FI)
 				{
-					return m68k_read_immediate_16(address);
+					return m68k_read_immediate_16(state, address);
 				}
 
-				uint32 data = m68ki_read_32(address & ~3);
+				uint32 data = m68ki_read_32(state, address & ~3);
 
 				//printf("m68k: doing cache fill at %08x (tag %08x idx %d)\n", address, tag, idx);
 
@@ -1143,7 +1143,7 @@ static inline uint32 m68ki_ic_readimm16(uint32 address)
 				}
 				else
 				{
-					return m68k_read_immediate_16(address);
+					return m68k_read_immediate_16(state, address);
 				}
 			}
 
@@ -1159,13 +1159,13 @@ static inline uint32 m68ki_ic_readimm16(uint32 address)
 			}
 		}
 	}
-	return m68k_read_immediate_16(address);
+	return m68k_read_immediate_16(state, address);
 }
 
 /* Handles all immediate reads, does address error check, function code setting,
  * and prefetching if they are enabled in m68kconf.h
  */
-uint m68ki_read_imm6_addr_slowpath(uint32_t pc, address_translation_cache *cache);
+uint m68ki_read_imm16_addr_slowpath(m68ki_cpu_core *state, uint32_t pc, address_translation_cache *cache);
 
 
 
@@ -1179,7 +1179,7 @@ static inline uint m68ki_read_imm_16(m68ki_cpu_core *state)
 		REG_PC += 2;
 		return be16toh(((unsigned short *)(cache->offset + pc))[0]);
 	}
-	return m68ki_read_imm6_addr_slowpath(pc, cache);
+	return m68ki_read_imm16_addr_slowpath(state, pc, cache);
 }
 
 static inline uint m68ki_read_imm_8(m68ki_cpu_core *state)
@@ -1216,16 +1216,16 @@ static inline uint m68ki_read_imm_32(m68ki_cpu_core *state)
 	if(REG_PC != CPU_PREF_ADDR)
 	{
 		CPU_PREF_ADDR = REG_PC;
-		CPU_PREF_DATA = m68ki_ic_readimm16(ADDRESS_68K(CPU_PREF_ADDR));
+		CPU_PREF_DATA = m68ki_ic_readimm16(state, ADDRESS_68K(CPU_PREF_ADDR));
 	}
 	temp_val = MASK_OUT_ABOVE_16(CPU_PREF_DATA);
 	REG_PC += 2;
 	CPU_PREF_ADDR = REG_PC;
-	CPU_PREF_DATA = m68ki_ic_readimm16(ADDRESS_68K(CPU_PREF_ADDR));
+	CPU_PREF_DATA = m68ki_ic_readimm16(state, ADDRESS_68K(CPU_PREF_ADDR));
 
 	temp_val = MASK_OUT_ABOVE_32((temp_val << 16) | MASK_OUT_ABOVE_16(CPU_PREF_DATA));
 	REG_PC += 2;
-	CPU_PREF_DATA = m68ki_ic_readimm16(REG_PC);
+	CPU_PREF_DATA = m68ki_ic_readimm16(state, REG_PC);
 	CPU_PREF_ADDR = m68ki_cpu.mmu_tmp_buserror_occurred ? ((uint32)~0) : REG_PC;
 
 	return temp_val;
@@ -1245,7 +1245,7 @@ static inline uint m68ki_read_imm_32(m68ki_cpu_core *state)
  * code if they are enabled in m68kconf.h.
  */
 
-static inline uint m68ki_read_8_fc(uint address, uint fc)
+static inline uint m68ki_read_8_fc(m68ki_cpu_core *state, uint address, uint fc)
 {
 	(void)fc;
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
@@ -1266,7 +1266,7 @@ static inline uint m68ki_read_8_fc(uint address, uint fc)
 
 	return m68k_read_memory_8(ADDRESS_68K(address));
 }
-static inline uint m68ki_read_16_fc(uint address, uint fc)
+static inline uint m68ki_read_16_fc(m68ki_cpu_core *state, uint address, uint fc)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
 	m68ki_cpu.mmu_tmp_fc = fc;
@@ -1276,7 +1276,7 @@ static inline uint m68ki_read_16_fc(uint address, uint fc)
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
-	    address = pmmu_translate_addr(address,1);
+	    address = pmmu_translate_addr(state, address,1);
 #endif
 
 	for (int i = 0; i < m68ki_cpu.read_ranges; i++) {
@@ -1287,7 +1287,7 @@ static inline uint m68ki_read_16_fc(uint address, uint fc)
 
 	return m68k_read_memory_16(ADDRESS_68K(address));
 }
-static inline uint m68ki_read_32_fc(uint address, uint fc)
+static inline uint m68ki_read_32_fc(m68ki_cpu_core *state, uint address, uint fc)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
 	m68ki_cpu.mmu_tmp_fc = fc;
@@ -1297,7 +1297,7 @@ static inline uint m68ki_read_32_fc(uint address, uint fc)
 
 #if M68K_EMULATE_PMMU
 	if (PMMU_ENABLED)
-	    address = pmmu_translate_addr(address,1);
+	    address = pmmu_translate_addr(state, address,1);
 #endif
 
 	for (int i = 0; i < m68ki_cpu.read_ranges; i++) {
@@ -1309,7 +1309,7 @@ static inline uint m68ki_read_32_fc(uint address, uint fc)
 	return m68k_read_memory_32(ADDRESS_68K(address));
 }
 
-static inline void m68ki_write_8_fc(uint address, uint fc, uint value)
+static inline void m68ki_write_8_fc(m68ki_cpu_core *state, uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
 	m68ki_cpu.mmu_tmp_fc = fc;
@@ -1330,7 +1330,7 @@ static inline void m68ki_write_8_fc(uint address, uint fc, uint value)
 
 	m68k_write_memory_8(ADDRESS_68K(address), value);
 }
-static inline void m68ki_write_16_fc(uint address, uint fc, uint value)
+static inline void m68ki_write_16_fc(m68ki_cpu_core *state, uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
 	m68ki_cpu.mmu_tmp_fc = fc;
@@ -1352,7 +1352,7 @@ static inline void m68ki_write_16_fc(uint address, uint fc, uint value)
 
 	m68k_write_memory_16(ADDRESS_68K(address), value);
 }
-static inline void m68ki_write_32_fc(uint address, uint fc, uint value)
+static inline void m68ki_write_32_fc(m68ki_cpu_core *state, uint address, uint fc, uint value)
 {
 	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
 	m68ki_cpu.mmu_tmp_fc = fc;
@@ -1524,111 +1524,111 @@ static inline uint m68ki_get_ea_ix(m68ki_cpu_core *state, uint An)
 
 	/* Postindex */
 	if(BIT_2(extension))                /* I/IS:  0 = preindex, 1 = postindex */
-		return m68ki_read_32(An + bd) + Xn + od;
+		return m68ki_read_32(state, An + bd) + Xn + od;
 
 	/* Preindex */
-	return m68ki_read_32(An + bd + Xn) + od;
+	return m68ki_read_32(state, An + bd + Xn) + od;
 }
 
 
 /* Fetch operands */
-static inline uint OPER_AY_AI_8(m68ki_cpu_core *state) {uint ea = EA_AY_AI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AY_AI_16(m68ki_cpu_core *state) {uint ea = EA_AY_AI_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AY_AI_32(m68ki_cpu_core *state) {uint ea = EA_AY_AI_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AY_PI_8(m68ki_cpu_core *state) {uint ea = EA_AY_PI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AY_PI_16(m68ki_cpu_core *state) {uint ea = EA_AY_PI_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AY_PI_32(m68ki_cpu_core *state) {uint ea = EA_AY_PI_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AY_PD_8(m68ki_cpu_core *state) {uint ea = EA_AY_PD_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AY_PD_16(m68ki_cpu_core *state) {uint ea = EA_AY_PD_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AY_PD_32(m68ki_cpu_core *state) {uint ea = EA_AY_PD_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AY_DI_8(m68ki_cpu_core *state) {uint ea = EA_AY_DI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AY_DI_16(m68ki_cpu_core *state) {uint ea = EA_AY_DI_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AY_DI_32(m68ki_cpu_core *state) {uint ea = EA_AY_DI_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AY_IX_8(m68ki_cpu_core *state) {uint ea = EA_AY_IX_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AY_IX_16(m68ki_cpu_core *state) {uint ea = EA_AY_IX_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AY_IX_32(m68ki_cpu_core *state) {uint ea = EA_AY_IX_32(); return m68ki_read_32(ea);}
+static inline uint OPER_AY_AI_8(m68ki_cpu_core *state) {uint ea = EA_AY_AI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AY_AI_16(m68ki_cpu_core *state) {uint ea = EA_AY_AI_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AY_AI_32(m68ki_cpu_core *state) {uint ea = EA_AY_AI_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AY_PI_8(m68ki_cpu_core *state) {uint ea = EA_AY_PI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AY_PI_16(m68ki_cpu_core *state) {uint ea = EA_AY_PI_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AY_PI_32(m68ki_cpu_core *state) {uint ea = EA_AY_PI_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AY_PD_8(m68ki_cpu_core *state) {uint ea = EA_AY_PD_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AY_PD_16(m68ki_cpu_core *state) {uint ea = EA_AY_PD_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AY_PD_32(m68ki_cpu_core *state) {uint ea = EA_AY_PD_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AY_DI_8(m68ki_cpu_core *state) {uint ea = EA_AY_DI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AY_DI_16(m68ki_cpu_core *state) {uint ea = EA_AY_DI_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AY_DI_32(m68ki_cpu_core *state) {uint ea = EA_AY_DI_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AY_IX_8(m68ki_cpu_core *state) {uint ea = EA_AY_IX_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AY_IX_16(m68ki_cpu_core *state) {uint ea = EA_AY_IX_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AY_IX_32(m68ki_cpu_core *state) {uint ea = EA_AY_IX_32(); return m68ki_read_32(state, ea);}
 
-static inline uint OPER_AX_AI_8(m68ki_cpu_core *state) {uint ea = EA_AX_AI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AX_AI_16(m68ki_cpu_core *state) {uint ea = EA_AX_AI_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AX_AI_32(m68ki_cpu_core *state) {uint ea = EA_AX_AI_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AX_PI_8(m68ki_cpu_core *state) {uint ea = EA_AX_PI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AX_PI_16(m68ki_cpu_core *state) {uint ea = EA_AX_PI_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AX_PI_32(m68ki_cpu_core *state) {uint ea = EA_AX_PI_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AX_PD_8(m68ki_cpu_core *state) {uint ea = EA_AX_PD_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AX_PD_16(m68ki_cpu_core *state) {uint ea = EA_AX_PD_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AX_PD_32(m68ki_cpu_core *state) {uint ea = EA_AX_PD_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AX_DI_8(m68ki_cpu_core *state) {uint ea = EA_AX_DI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AX_DI_16(m68ki_cpu_core *state) {uint ea = EA_AX_DI_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AX_DI_32(m68ki_cpu_core *state) {uint ea = EA_AX_DI_32(); return m68ki_read_32(ea);}
-static inline uint OPER_AX_IX_8(m68ki_cpu_core *state) {uint ea = EA_AX_IX_8();  return m68ki_read_8(ea); }
-static inline uint OPER_AX_IX_16(m68ki_cpu_core *state) {uint ea = EA_AX_IX_16(); return m68ki_read_16(ea);}
-static inline uint OPER_AX_IX_32(m68ki_cpu_core *state) {uint ea = EA_AX_IX_32(); return m68ki_read_32(ea);}
+static inline uint OPER_AX_AI_8(m68ki_cpu_core *state) {uint ea = EA_AX_AI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AX_AI_16(m68ki_cpu_core *state) {uint ea = EA_AX_AI_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AX_AI_32(m68ki_cpu_core *state) {uint ea = EA_AX_AI_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AX_PI_8(m68ki_cpu_core *state) {uint ea = EA_AX_PI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AX_PI_16(m68ki_cpu_core *state) {uint ea = EA_AX_PI_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AX_PI_32(m68ki_cpu_core *state) {uint ea = EA_AX_PI_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AX_PD_8(m68ki_cpu_core *state) {uint ea = EA_AX_PD_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AX_PD_16(m68ki_cpu_core *state) {uint ea = EA_AX_PD_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AX_PD_32(m68ki_cpu_core *state) {uint ea = EA_AX_PD_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AX_DI_8(m68ki_cpu_core *state) {uint ea = EA_AX_DI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AX_DI_16(m68ki_cpu_core *state) {uint ea = EA_AX_DI_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AX_DI_32(m68ki_cpu_core *state) {uint ea = EA_AX_DI_32(); return m68ki_read_32(state, ea);}
+static inline uint OPER_AX_IX_8(m68ki_cpu_core *state) {uint ea = EA_AX_IX_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_AX_IX_16(m68ki_cpu_core *state) {uint ea = EA_AX_IX_16(); return m68ki_read_16(state, ea);}
+static inline uint OPER_AX_IX_32(m68ki_cpu_core *state) {uint ea = EA_AX_IX_32(); return m68ki_read_32(state, ea);}
 
-static inline uint OPER_A7_PI_8(m68ki_cpu_core *state) {uint ea = EA_A7_PI_8();  return m68ki_read_8(ea); }
-static inline uint OPER_A7_PD_8(m68ki_cpu_core *state) {uint ea = EA_A7_PD_8();  return m68ki_read_8(ea); }
+static inline uint OPER_A7_PI_8(m68ki_cpu_core *state) {uint ea = EA_A7_PI_8();  return m68ki_read_8(state, ea); }
+static inline uint OPER_A7_PD_8(m68ki_cpu_core *state) {uint ea = EA_A7_PD_8();  return m68ki_read_8(state, ea); }
 
-static inline uint OPER_AW_8(m68ki_cpu_core *state) {uint ea = EA_AW_8();     return m68ki_read_8(ea); }
-static inline uint OPER_AW_16(m68ki_cpu_core *state) {uint ea = EA_AW_16();    return m68ki_read_16(ea);}
-static inline uint OPER_AW_32(m68ki_cpu_core *state) {uint ea = EA_AW_32();    return m68ki_read_32(ea);}
-static inline uint OPER_AL_8(m68ki_cpu_core *state) {uint ea = EA_AL_8();     return m68ki_read_8(ea); }
-static inline uint OPER_AL_16(m68ki_cpu_core *state) {uint ea = EA_AL_16();    return m68ki_read_16(ea);}
-static inline uint OPER_AL_32(m68ki_cpu_core *state) {uint ea = EA_AL_32();    return m68ki_read_32(ea);}
-static inline uint OPER_PCDI_8(m68ki_cpu_core *state) {uint ea = EA_PCDI_8();   return m68ki_read_pcrel_8(ea); }
-static inline uint OPER_PCDI_16(m68ki_cpu_core *state) {uint ea = EA_PCDI_16();  return m68ki_read_pcrel_16(ea);}
-static inline uint OPER_PCDI_32(m68ki_cpu_core *state) {uint ea = EA_PCDI_32();  return m68ki_read_pcrel_32(ea);}
-static inline uint OPER_PCIX_8(m68ki_cpu_core *state) {uint ea = EA_PCIX_8();   return m68ki_read_pcrel_8(ea); }
-static inline uint OPER_PCIX_16(m68ki_cpu_core *state) {uint ea = EA_PCIX_16();  return m68ki_read_pcrel_16(ea);}
-static inline uint OPER_PCIX_32(m68ki_cpu_core *state) {uint ea = EA_PCIX_32();  return m68ki_read_pcrel_32(ea);}
+static inline uint OPER_AW_8(m68ki_cpu_core *state) {uint ea = EA_AW_8();     return m68ki_read_8(state, ea); }
+static inline uint OPER_AW_16(m68ki_cpu_core *state) {uint ea = EA_AW_16();    return m68ki_read_16(state, ea);}
+static inline uint OPER_AW_32(m68ki_cpu_core *state) {uint ea = EA_AW_32();    return m68ki_read_32(state, ea);}
+static inline uint OPER_AL_8(m68ki_cpu_core *state) {uint ea = EA_AL_8();     return m68ki_read_8(state, ea); }
+static inline uint OPER_AL_16(m68ki_cpu_core *state) {uint ea = EA_AL_16();    return m68ki_read_16(state, ea);}
+static inline uint OPER_AL_32(m68ki_cpu_core *state) {uint ea = EA_AL_32();    return m68ki_read_32(state, ea);}
+static inline uint OPER_PCDI_8(m68ki_cpu_core *state) {uint ea = EA_PCDI_8();   return m68ki_read_pcrel_8(state, ea);}
+static inline uint OPER_PCDI_16(m68ki_cpu_core *state) {uint ea = EA_PCDI_16();  return m68ki_read_pcrel_16(state, ea);}
+static inline uint OPER_PCDI_32(m68ki_cpu_core *state) {uint ea = EA_PCDI_32();  return m68ki_read_pcrel_32(state, ea);}
+static inline uint OPER_PCIX_8(m68ki_cpu_core *state) {uint ea = EA_PCIX_8();   return m68ki_read_pcrel_8(state, ea);}
+static inline uint OPER_PCIX_16(m68ki_cpu_core *state) {uint ea = EA_PCIX_16();  return m68ki_read_pcrel_16(state, ea);}
+static inline uint OPER_PCIX_32(m68ki_cpu_core *state) {uint ea = EA_PCIX_32();  return m68ki_read_pcrel_32(state, ea);}
 
 
 
 /* ---------------------------- Stack Functions --------------------------- */
 
 /* Push/pull data from the stack */
-static inline void m68ki_push_16(uint value)
+static inline void m68ki_push_16(m68ki_cpu_core *state, uint value)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 2);
-	m68ki_write_16(REG_SP, value);
+	m68ki_write_16(state, REG_SP, value);
 }
 
-static inline void m68ki_push_32(uint value)
+static inline void m68ki_push_32(m68ki_cpu_core *state, uint value)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 4);
-	m68ki_write_32(REG_SP, value);
+	m68ki_write_32(state, REG_SP, value);
 }
 
-static inline uint m68ki_pull_16(void)
+static inline uint m68ki_pull_16(m68ki_cpu_core *state)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 2);
-	return m68ki_read_16(REG_SP-2);
+	return m68ki_read_16(state, REG_SP - 2);
 }
 
-static inline uint m68ki_pull_32(void)
+static inline uint m68ki_pull_32(m68ki_cpu_core *state)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 4);
-	return m68ki_read_32(REG_SP-4);
+	return m68ki_read_32(state, REG_SP - 4);
 }
 
 
 /* Increment/decrement the stack as if doing a push/pull but
  * don't do any memory access.
  */
-static inline void m68ki_fake_push_16(void)
+static inline void m68ki_fake_push_16(m68ki_cpu_core *state)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 2);
 }
 
-static inline void m68ki_fake_push_32(void)
+static inline void m68ki_fake_push_32(m68ki_cpu_core *state)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 4);
 }
 
-static inline void m68ki_fake_pull_16(void)
+static inline void m68ki_fake_pull_16(m68ki_cpu_core *state)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 2);
 }
 
-static inline void m68ki_fake_pull_32(void)
+static inline void m68ki_fake_pull_32(m68ki_cpu_core *state)
 {
 	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 4);
 }
@@ -1646,10 +1646,10 @@ static inline void m68ki_jump(uint new_pc)
 	m68ki_pc_changed(REG_PC);
 }
 
-static inline void m68ki_jump_vector(uint vector)
+static inline void m68ki_jump_vector(m68ki_cpu_core *state, uint vector)
 {
 	REG_PC = (vector<<2) + REG_VBR;
-	REG_PC = m68ki_read_data_32(REG_PC);
+	REG_PC = m68ki_read_data_32(state, REG_PC);
 	m68ki_pc_changed(REG_PC);
 }
 
@@ -1779,116 +1779,116 @@ static inline uint m68ki_init_exception(void)
 }
 
 /* 3 word stack frame (68000 only) */
-static inline void m68ki_stack_frame_3word(uint pc, uint sr)
+static inline void m68ki_stack_frame_3word(m68ki_cpu_core *state, uint pc, uint sr)
 {
-	m68ki_push_32(pc);
-	m68ki_push_16(sr);
+	m68ki_push_32(state, pc);
+	m68ki_push_16(state, sr);
 }
 
 /* Format 0 stack frame.
  * This is the standard stack frame for 68010+.
  */
-static inline void m68ki_stack_frame_0000(uint pc, uint sr, uint vector)
+static inline void m68ki_stack_frame_0000(m68ki_cpu_core *state, uint pc, uint sr, uint vector)
 {
 	/* Stack a 3-word frame if we are 68000 */
 	if(CPU_TYPE == CPU_TYPE_000)
 	{
-		m68ki_stack_frame_3word(pc, sr);
+		m68ki_stack_frame_3word(state, pc, sr);
 		return;
 	}
-	m68ki_push_16(vector<<2);
-	m68ki_push_32(pc);
-	m68ki_push_16(sr);
+	m68ki_push_16(state, vector << 2);
+	m68ki_push_32(state, pc);
+	m68ki_push_16(state, sr);
 }
 
 /* Format 1 stack frame (68020).
  * For 68020, this is the 4 word throwaway frame.
  */
-static inline void m68ki_stack_frame_0001(uint pc, uint sr, uint vector)
+static inline void m68ki_stack_frame_0001(m68ki_cpu_core *state, uint pc, uint sr, uint vector)
 {
-	m68ki_push_16(0x1000 | (vector<<2));
-	m68ki_push_32(pc);
-	m68ki_push_16(sr);
+	m68ki_push_16(state, 0x1000 | (vector << 2));
+	m68ki_push_32(state, pc);
+	m68ki_push_16(state, sr);
 }
 
 /* Format 2 stack frame.
  * This is used only by 68020 for trap exceptions.
  */
-static inline void m68ki_stack_frame_0010(uint sr, uint vector)
+static inline void m68ki_stack_frame_0010(m68ki_cpu_core *state, uint sr, uint vector)
 {
-	m68ki_push_32(REG_PPC);
-	m68ki_push_16(0x2000 | (vector<<2));
-	m68ki_push_32(REG_PC);
-	m68ki_push_16(sr);
+	m68ki_push_32(state, REG_PPC);
+	m68ki_push_16(state, 0x2000 | (vector << 2));
+	m68ki_push_32(state, REG_PC);
+	m68ki_push_16(state, sr);
 }
 
 
 /* Bus error stack frame (68000 only).
  */
-static inline void m68ki_stack_frame_buserr(uint sr)
+static inline void m68ki_stack_frame_buserr(m68ki_cpu_core *state, uint sr)
 {
-	m68ki_push_32(REG_PC);
-	m68ki_push_16(sr);
-	m68ki_push_16(REG_IR);
-	m68ki_push_32(m68ki_aerr_address);	/* access address */
+	m68ki_push_32(state, REG_PC);
+	m68ki_push_16(state, sr);
+	m68ki_push_16(state, REG_IR);
+	m68ki_push_32(state, m68ki_aerr_address);	/* access address */
 	/* 0 0 0 0 0 0 0 0 0 0 0 R/W I/N FC
 	 * R/W  0 = write, 1 = read
 	 * I/N  0 = instruction, 1 = not
 	 * FC   3-bit function code
 	 */
-	m68ki_push_16(m68ki_aerr_write_mode | CPU_INSTR_MODE | m68ki_aerr_fc);
+	m68ki_push_16(state, m68ki_aerr_write_mode | CPU_INSTR_MODE | m68ki_aerr_fc);
 }
 
 /* Format 8 stack frame (68010).
  * 68010 only.  This is the 29 word bus/address error frame.
  */
-static inline void m68ki_stack_frame_1000(uint pc, uint sr, uint vector)
+static inline void m68ki_stack_frame_1000(m68ki_cpu_core *state, uint pc, uint sr, uint vector)
 {
 	/* VERSION
 	 * NUMBER
 	 * INTERNAL INFORMATION, 16 WORDS
 	 */
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
-	m68ki_fake_push_32();
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
+	m68ki_fake_push_32(state);
 
 	/* INSTRUCTION INPUT BUFFER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* UNUSED, RESERVED (not written) */
-	m68ki_fake_push_16();
+	m68ki_fake_push_16(state);
 
 	/* DATA INPUT BUFFER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* UNUSED, RESERVED (not written) */
-	m68ki_fake_push_16();
+	m68ki_fake_push_16(state);
 
 	/* DATA OUTPUT BUFFER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* UNUSED, RESERVED (not written) */
-	m68ki_fake_push_16();
+	m68ki_fake_push_16(state);
 
 	/* FAULT ADDRESS */
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
 
 	/* SPECIAL STATUS WORD */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* 1000, VECTOR OFFSET */
-	m68ki_push_16(0x8000 | (vector<<2));
+	m68ki_push_16(state, 0x8000 | (vector << 2));
 
 	/* PROGRAM COUNTER */
-	m68ki_push_32(pc);
+	m68ki_push_32(state, pc);
 
 	/* STATUS REGISTER */
-	m68ki_push_16(sr);
+	m68ki_push_16(state, sr);
 }
 
 /* Format A stack frame (short bus fault).
@@ -1896,52 +1896,52 @@ static inline void m68ki_stack_frame_1000(uint pc, uint sr, uint vector)
  * if the error happens at an instruction boundary.
  * PC stacked is address of next instruction.
  */
-static inline void m68ki_stack_frame_1010(uint sr, uint vector, uint pc, uint fault_address)
+static inline void m68ki_stack_frame_1010(m68ki_cpu_core *state, uint sr, uint vector, uint pc, uint fault_address)
 {
 	int orig_rw = m68ki_cpu.mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
 	int orig_fc = m68ki_cpu.mmu_tmp_buserror_fc;
 	int orig_sz = m68ki_cpu.mmu_tmp_buserror_sz;
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* DATA OUTPUT BUFFER (2 words) */
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* DATA CYCLE FAULT ADDRESS (2 words) */
-	m68ki_push_32(fault_address);
+	m68ki_push_32(state, fault_address);
 
 	/* INSTRUCTION PIPE STAGE B */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* INSTRUCTION PIPE STAGE C */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* SPECIAL STATUS REGISTER */
 	// set bit for: Rerun Faulted bus Cycle, or run pending prefetch
 	// set FC
-	m68ki_push_16(0x0100 | orig_fc | orig_rw<<6 | orig_sz<<4);
+	m68ki_push_16(state, 0x0100 | orig_fc | orig_rw << 6 | orig_sz << 4);
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* 1010, VECTOR OFFSET */
-	m68ki_push_16(0xa000 | (vector<<2));
+	m68ki_push_16(state, 0xa000 | (vector << 2));
 
 	/* PROGRAM COUNTER */
-	m68ki_push_32(pc);
+	m68ki_push_32(state, pc);
 
 	/* STATUS REGISTER */
-	m68ki_push_16(sr);
+	m68ki_push_16(state, sr);
 }
 
 /* Format B stack frame (long bus fault).
@@ -1949,150 +1949,151 @@ static inline void m68ki_stack_frame_1010(uint sr, uint vector, uint pc, uint fa
  * if the error happens during instruction execution.
  * PC stacked is address of instruction in progress.
  */
-static inline void m68ki_stack_frame_1011(uint sr, uint vector, uint pc, uint fault_address)
+static inline void m68ki_stack_frame_1011(m68ki_cpu_core *state, uint sr, uint vector, uint pc, uint fault_address)
 {
 	int orig_rw = m68ki_cpu.mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
 	int orig_fc = m68ki_cpu.mmu_tmp_buserror_fc;
 	int orig_sz = m68ki_cpu.mmu_tmp_buserror_sz;
 	/* INTERNAL REGISTERS (18 words) */
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
 
 	/* VERSION# (4 bits), INTERNAL INFORMATION */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* INTERNAL REGISTERS (3 words) */
-	m68ki_push_32(0);
-	m68ki_push_16(0);
+	m68ki_push_32(state, 0);
+	m68ki_push_16(state, 0);
 
 	/* DATA INTPUT BUFFER (2 words) */
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
 
 	/* INTERNAL REGISTERS (2 words) */
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
 
 	/* STAGE B ADDRESS (2 words) */
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
 
 	/* INTERNAL REGISTER (4 words) */
-	m68ki_push_32(0);
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
 
 	/* DATA OUTPUT BUFFER (2 words) */
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* DATA CYCLE FAULT ADDRESS (2 words) */
-	m68ki_push_32(fault_address);
+	m68ki_push_32(state, fault_address);
 
 	/* INSTRUCTION PIPE STAGE B */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* INSTRUCTION PIPE STAGE C */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* SPECIAL STATUS REGISTER */
-	m68ki_push_16(0x0100 | orig_fc | (orig_rw<<6) | (orig_sz<<4));
+	m68ki_push_16(state, 0x0100 | orig_fc | (orig_rw << 6) | (orig_sz << 4));
 
 	/* INTERNAL REGISTER */
-	m68ki_push_16(0);
+	m68ki_push_16(state, 0);
 
 	/* 1011, VECTOR OFFSET */
-	m68ki_push_16(0xb000 | (vector<<2));
+	m68ki_push_16(state, 0xb000 | (vector << 2));
 
 	/* PROGRAM COUNTER */
-	m68ki_push_32(pc);
+	m68ki_push_32(state, pc);
 
 	/* STATUS REGISTER */
-	m68ki_push_16(sr);
+	m68ki_push_16(state, sr);
 }
 
 /* Type 7 stack frame (access fault).
  * This is used by the 68040 for bus fault and mmu trap
  * 30 words
  */
-static inline void m68ki_stack_frame_0111(uint sr, uint vector, uint pc, uint fault_address, uint8 in_mmu)
+static inline void
+m68ki_stack_frame_0111(m68ki_cpu_core *state, uint sr, uint vector, uint pc, uint fault_address, uint8 in_mmu)
 {
 	int orig_rw = m68ki_cpu.mmu_tmp_buserror_rw;    // this gets splatted by the following pushes, so save it now
 	int orig_fc = m68ki_cpu.mmu_tmp_buserror_fc;
 
 	/* INTERNAL REGISTERS (18 words) */
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
-	m68ki_push_32(0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
+	m68ki_push_32(state, 0);
 
 	/* FAULT ADDRESS (2 words) */
-	m68ki_push_32(fault_address);
+	m68ki_push_32(state, fault_address);
 
 	/* INTERNAL REGISTERS (3 words) */
-	m68ki_push_32(0);
-	m68ki_push_16(0);
+	m68ki_push_32(state, 0);
+	m68ki_push_16(state, 0);
 
 	/* SPECIAL STATUS REGISTER (1 word) */
-	m68ki_push_16((in_mmu ? 0x400 : 0) | orig_fc | (orig_rw<<8));
+	m68ki_push_16(state, (in_mmu ? 0x400 : 0) | orig_fc | (orig_rw << 8));
 
 	/* EFFECTIVE ADDRESS (2 words) */
-	m68ki_push_32(fault_address);
+	m68ki_push_32(state, fault_address);
 
 	/* 0111, VECTOR OFFSET (1 word) */
-	m68ki_push_16(0x7000 | (vector<<2));
+	m68ki_push_16(state, 0x7000 | (vector << 2));
 
 	/* PROGRAM COUNTER (2 words) */
-	m68ki_push_32(pc);
+	m68ki_push_32(state, pc);
 
 	/* STATUS REGISTER (1 word) */
-	m68ki_push_16(sr);
+	m68ki_push_16(state, sr);
 }
 
 /* Used for Group 2 exceptions.
  * These stack a type 2 frame on the 020.
  */
-static inline void m68ki_exception_trap(uint vector)
+static inline void m68ki_exception_trap(m68ki_cpu_core *state, uint vector)
 {
 	uint sr = m68ki_init_exception();
 
 	if(CPU_TYPE_IS_010_LESS(CPU_TYPE))
-		m68ki_stack_frame_0000(REG_PC, sr, vector);
+		m68ki_stack_frame_0000(state, REG_PC, sr, vector);
 	else
-		m68ki_stack_frame_0010(sr, vector);
+		m68ki_stack_frame_0010(state, sr, vector);
 
-	m68ki_jump_vector(vector);
+	m68ki_jump_vector(state, vector);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[vector] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Trap#n stacks a 0 frame but behaves like group2 otherwise */
-static inline void m68ki_exception_trapN(uint vector)
+static inline void m68ki_exception_trapN(m68ki_cpu_core *state, uint vector)
 {
 	uint sr = m68ki_init_exception();
-	m68ki_stack_frame_0000(REG_PC, sr, vector);
-	m68ki_jump_vector(vector);
+	m68ki_stack_frame_0000(state, REG_PC, sr, vector);
+	m68ki_jump_vector(state, vector);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[vector] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Exception for trace mode */
-static inline void m68ki_exception_trace(void)
+static inline void m68ki_exception_trace(m68ki_cpu_core *state)
 {
 	uint sr = m68ki_init_exception();
 
@@ -2104,12 +2105,12 @@ static inline void m68ki_exception_trace(void)
 			CPU_INSTR_MODE = INSTRUCTION_NO;
 		}
 		#endif /* M68K_EMULATE_ADDRESS_ERROR */
-		m68ki_stack_frame_0000(REG_PC, sr, EXCEPTION_TRACE);
+		m68ki_stack_frame_0000(state, REG_PC, sr, EXCEPTION_TRACE);
 	}
 	else
-		m68ki_stack_frame_0010(sr, EXCEPTION_TRACE);
+		m68ki_stack_frame_0010(state, sr, EXCEPTION_TRACE);
 
-	m68ki_jump_vector(EXCEPTION_TRACE);
+	m68ki_jump_vector(state, EXCEPTION_TRACE);
 
 	/* Trace nullifies a STOP instruction */
 	CPU_STOPPED &= ~STOP_LEVEL_STOP;
@@ -2119,7 +2120,7 @@ static inline void m68ki_exception_trace(void)
 }
 
 /* Exception for privilege violation */
-static inline void m68ki_exception_privilege_violation(void)
+static inline void m68ki_exception_privilege_violation(m68ki_cpu_core *state)
 {
 	uint sr = m68ki_init_exception();
 
@@ -2130,8 +2131,8 @@ static inline void m68ki_exception_privilege_violation(void)
 	}
 	#endif /* M68K_EMULATE_ADDRESS_ERROR */
 
-	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_PRIVILEGE_VIOLATION);
-	m68ki_jump_vector(EXCEPTION_PRIVILEGE_VIOLATION);
+	m68ki_stack_frame_0000(state, REG_PPC, sr, EXCEPTION_PRIVILEGE_VIOLATION);
+	m68ki_jump_vector(state, EXCEPTION_PRIVILEGE_VIOLATION);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_PRIVILEGE_VIOLATION] - CYC_INSTRUCTION[REG_IR]);
@@ -2142,7 +2143,7 @@ extern jmp_buf m68ki_bus_error_jmp_buf;
 #define m68ki_check_bus_error_trap() setjmp(m68ki_bus_error_jmp_buf)
 
 /* Exception for bus error */
-static inline void m68ki_exception_bus_error(void)
+static inline void m68ki_exception_bus_error(m68ki_cpu_core *state)
 {
 	int i;
 
@@ -2166,16 +2167,16 @@ static inline void m68ki_exception_bus_error(void)
 	}
 
 	uint sr = m68ki_init_exception();
-	m68ki_stack_frame_1000(REG_PPC, sr, EXCEPTION_BUS_ERROR);
+	m68ki_stack_frame_1000(state, REG_PPC, sr, EXCEPTION_BUS_ERROR);
 
-	m68ki_jump_vector(EXCEPTION_BUS_ERROR);
+	m68ki_jump_vector(state, EXCEPTION_BUS_ERROR);
 	longjmp(m68ki_bus_error_jmp_buf, 1);
 }
 
 extern int cpu_log_enabled;
 
 /* Exception for A-Line instructions */
-static inline void m68ki_exception_1010(void)
+static inline void m68ki_exception_1010(m68ki_cpu_core *state)
 {
 	uint sr;
 #if M68K_LOG_1010_1111 == OPT_ON
@@ -2185,15 +2186,15 @@ static inline void m68ki_exception_1010(void)
 #endif
 
 	sr = m68ki_init_exception();
-	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_1010);
-	m68ki_jump_vector(EXCEPTION_1010);
+	m68ki_stack_frame_0000(state, REG_PPC, sr, EXCEPTION_1010);
+	m68ki_jump_vector(state, EXCEPTION_1010);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_1010] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Exception for F-Line instructions */
-static inline void m68ki_exception_1111(void)
+static inline void m68ki_exception_1111(m68ki_cpu_core *state)
 {
 	uint sr;
 
@@ -2204,8 +2205,8 @@ static inline void m68ki_exception_1111(void)
 #endif
 
 	sr = m68ki_init_exception();
-	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_1111);
-	m68ki_jump_vector(EXCEPTION_1111);
+	m68ki_stack_frame_0000(state, REG_PPC, sr, EXCEPTION_1111);
+	m68ki_jump_vector(state, EXCEPTION_1111);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_1111] - CYC_INSTRUCTION[REG_IR]);
@@ -2216,7 +2217,7 @@ extern int m68ki_illg_callback(int);
 #endif
 
 /* Exception for illegal instructions */
-static inline void m68ki_exception_illegal(void)
+static inline void m68ki_exception_illegal(m68ki_cpu_core *state)
 {
 	uint sr;
 
@@ -2235,26 +2236,26 @@ static inline void m68ki_exception_illegal(void)
 	}
 	#endif /* M68K_EMULATE_ADDRESS_ERROR */
 
-	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_ILLEGAL_INSTRUCTION);
-	m68ki_jump_vector(EXCEPTION_ILLEGAL_INSTRUCTION);
+	m68ki_stack_frame_0000(state, REG_PPC, sr, EXCEPTION_ILLEGAL_INSTRUCTION);
+	m68ki_jump_vector(state, EXCEPTION_ILLEGAL_INSTRUCTION);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_ILLEGAL_INSTRUCTION] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Exception for format errror in RTE */
-static inline void m68ki_exception_format_error(void)
+static inline void m68ki_exception_format_error(m68ki_cpu_core *state)
 {
 	uint sr = m68ki_init_exception();
-	m68ki_stack_frame_0000(REG_PC, sr, EXCEPTION_FORMAT_ERROR);
-	m68ki_jump_vector(EXCEPTION_FORMAT_ERROR);
+	m68ki_stack_frame_0000(state, REG_PC, sr, EXCEPTION_FORMAT_ERROR);
+	m68ki_jump_vector(state, EXCEPTION_FORMAT_ERROR);
 
 	/* Use up some clock cycles and undo the instruction's cycles */
 	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_FORMAT_ERROR] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Exception for address error */
-static inline void m68ki_exception_address_error(void)
+static inline void m68ki_exception_address_error(m68ki_cpu_core *state)
 {
 	uint32 sr = m68ki_init_exception();
 
@@ -2274,23 +2275,23 @@ static inline void m68ki_exception_address_error(void)
 	if (CPU_TYPE_IS_000(CPU_TYPE))
 	{
 		/* Note: This is implemented for 68000 only! */
-		m68ki_stack_frame_buserr(sr);
+		m68ki_stack_frame_buserr(state, sr);
 	}
 	else if (CPU_TYPE_IS_010(CPU_TYPE))
 	{
 		/* only the 68010 throws this unique type-1000 frame */
-		m68ki_stack_frame_1000(REG_PPC, sr, EXCEPTION_BUS_ERROR);
+		m68ki_stack_frame_1000(state, REG_PPC, sr, EXCEPTION_BUS_ERROR);
 	}
 	else if (m68ki_cpu.mmu_tmp_buserror_address == REG_PPC)
 	{
-		m68ki_stack_frame_1010(sr, EXCEPTION_BUS_ERROR, REG_PPC, m68ki_cpu.mmu_tmp_buserror_address);
+		m68ki_stack_frame_1010(state, sr, EXCEPTION_BUS_ERROR, REG_PPC, m68ki_cpu.mmu_tmp_buserror_address);
 	}
 	else
 	{
-		m68ki_stack_frame_1011(sr, EXCEPTION_BUS_ERROR, REG_PPC, m68ki_cpu.mmu_tmp_buserror_address);
+		m68ki_stack_frame_1011(state, sr, EXCEPTION_BUS_ERROR, REG_PPC, m68ki_cpu.mmu_tmp_buserror_address);
 	}
 
-	m68ki_jump_vector(EXCEPTION_ADDRESS_ERROR);
+	m68ki_jump_vector(state, EXCEPTION_ADDRESS_ERROR);
 
 	m68ki_cpu.run_mode = RUN_MODE_BERR_AERR_RESET;
 
@@ -2303,7 +2304,7 @@ static inline void m68ki_exception_address_error(void)
 
 
 /* Service an interrupt request and start exception processing */
-static inline void m68ki_exception_interrupt(uint int_level)
+static inline void m68ki_exception_interrupt(m68ki_cpu_core *state, uint int_level)
 {
 	uint vector;
 	uint sr;
@@ -2347,20 +2348,20 @@ static inline void m68ki_exception_interrupt(uint int_level)
 	FLAG_INT_MASK = int_level<<8;
 
 	/* Get the new PC */
-	new_pc = m68ki_read_data_32((vector<<2) + REG_VBR);
+	new_pc = m68ki_read_data_32(state, (vector << 2) + REG_VBR);
 
 	/* If vector is uninitialized, call the uninitialized interrupt vector */
 	if(new_pc == 0)
-		new_pc = m68ki_read_data_32((EXCEPTION_UNINITIALIZED_INTERRUPT<<2) + REG_VBR);
+		new_pc = m68ki_read_data_32(state, (EXCEPTION_UNINITIALIZED_INTERRUPT << 2) + REG_VBR);
 
 	/* Generate a stack frame */
-	m68ki_stack_frame_0000(REG_PC, sr, vector);
+	m68ki_stack_frame_0000(state, REG_PC, sr, vector);
 	if(FLAG_M && CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
 	{
 		/* Create throwaway frame */
 		m68ki_set_sm_flag(FLAG_S);	/* clear M */
 		sr |= 0x2000; /* Same as SR in master stack frame except S is forced high */
-		m68ki_stack_frame_0001(REG_PC, sr, vector);
+		m68ki_stack_frame_0001(state, REG_PC, sr, vector);
 	}
 
 	m68ki_jump(new_pc);
@@ -2381,10 +2382,10 @@ static inline void m68ki_check_interrupts(m68ki_cpu_core *state)
 	if(m68ki_cpu.nmi_pending)
 	{
 		m68ki_cpu.nmi_pending = FALSE;
-		m68ki_exception_interrupt(7);
+		m68ki_exception_interrupt(state, 7);
 	}
 	else if(CPU_INT_LEVEL > FLAG_INT_MASK)
-		m68ki_exception_interrupt(CPU_INT_LEVEL>>8);
+		m68ki_exception_interrupt(state, CPU_INT_LEVEL >> 8);
 }
 
 

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -946,7 +946,7 @@ typedef struct
 
 
 
-typedef struct
+typedef struct m68ki_cpu_core
 {
 	uint cpu_type;     /* CPU Type: 68000, 68008, 68010, 68EC020, 68020, 68EC030, 68030, 68EC040, or 68040 */
 	uint dar[16];      /* Data and Address Registers */

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1099,7 +1099,7 @@ char* m68ki_disassemble_quick(unsigned int pc, unsigned int cpu_type);
 /* ---------------------------- Read Immediate ---------------------------- */
 
 // clear the instruction cache
-inline void m68ki_ic_clear()
+inline void m68ki_ic_clear(m68ki_cpu_core *state)
 {
 	int i;
 	for (i=0; i< M68K_IC_SIZE; i++) {

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -251,7 +251,7 @@ static inline void store_pack_float80(m68ki_cpu_core *state, uint32 ea, int k, f
 		{
 			dw2 &= pkmask2[17];
 			dw3 &= pkmask3[17];
-//			m68ki_cpu.fpcr |=  (need to set OPERR bit)
+//			state->fpcr |=  (need to set OPERR bit)
 		}
 	}
 
@@ -2078,7 +2078,7 @@ static void fbcc32(m68ki_cpu_core *state)
 
 void m68040_fpu_op0(m68ki_cpu_core *state)
 {
-	m68ki_cpu.fpu_just_reset = 0;
+	state->fpu_just_reset = 0;
 
 	switch ((REG_IR >> 6) & 0x3)
 	{
@@ -2150,7 +2150,7 @@ void m68040_fpu_op0(m68ki_cpu_core *state)
 
 static int perform_fsave(m68ki_cpu_core *state, uint32 addr, int inc)
 {
-	if(m68ki_cpu.cpu_type & CPU_TYPE_040)
+	if(state->cpu_type & CPU_TYPE_040)
 	{
 		if(inc)
 		{
@@ -2205,12 +2205,12 @@ static void do_frestore_null(m68ki_cpu_core *state)
 
 	// Mac IIci at 408458e6 wants an FSAVE of a just-restored NULL frame to also be NULL
 	// The PRM says it's possible to generate a NULL frame, but not how/when/why.  (need the 68881/68882 manual!)
-	m68ki_cpu.fpu_just_reset = 1;
+	state->fpu_just_reset = 1;
 }
 
 void m68040_do_fsave(m68ki_cpu_core *state, uint32 addr, int reg, int inc)
 {
-	if (m68ki_cpu.fpu_just_reset)
+	if (state->fpu_just_reset)
 	{
 		m68ki_write_32(state, addr, 0);
 	}
@@ -2230,11 +2230,11 @@ void m68040_do_frestore(m68ki_cpu_core *state, uint32 addr, int reg)
 	if (temp & 0xff000000)
 	{
 		// we don't handle non-nullptr frames
-		m68ki_cpu.fpu_just_reset = 0;
+		state->fpu_just_reset = 0;
 
 		if (reg != -1)
 		{
-			uint8 m40 = !!(m68ki_cpu.cpu_type & CPU_TYPE_040);
+			uint8 m40 = !!(state->cpu_type & CPU_TYPE_040);
 			// how about an IDLE frame?
 			if (!m40 && ((temp & 0x00ff0000) == 0x00180000))
 			{

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -4,6 +4,7 @@
 #include <stdarg.h>
 
 #include "softfloat/softfloat.h"
+
 float_status status;
 
 extern void exit(int);
@@ -380,7 +381,7 @@ static inline int TEST_CONDITION(int condition)
 	return r;
 }
 
-static uint8 READ_EA_8(int ea)
+static uint8 READ_EA_8(m68ki_cpu_core *state, int ea)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -422,13 +423,13 @@ static uint8 READ_EA_8(int ea)
 			{
 				case 0:		// (xxx).W
 				{
-					uint32 ea = (uint32)OPER_I_16();
+					uint32 ea = (uint32) OPER_I_16(state);
 					return m68ki_read_8(ea);
 				}
 				case 1:		// (xxx).L
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					return m68ki_read_8(ea);
 				}
@@ -439,12 +440,12 @@ static uint8 READ_EA_8(int ea)
 				}
 				case 3:     // (PC) + (Xn) + d8
 				{
-					uint32 ea =  EA_PCIX_8();
+					uint32 ea = EA_PCIX_8();
 					return m68ki_read_8(ea);
 				}
 				case 4:		// #<data>
 				{
-					return  OPER_I_8();
+					return OPER_I_8(state);
 				}
 				default:	fatalerror("M68kFPU: READ_EA_8: unhandled mode %d, reg %d at %08X\n", mode, reg, REG_PC);
 			}
@@ -456,7 +457,7 @@ static uint8 READ_EA_8(int ea)
 	return 0;
 }
 
-static uint16 READ_EA_16(int ea)
+static uint16 READ_EA_16(m68ki_cpu_core *state, int ea)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -498,13 +499,13 @@ static uint16 READ_EA_16(int ea)
 			{
 				case 0:		// (xxx).W
 				{
-					uint32 ea = (uint32)OPER_I_16();
+					uint32 ea = (uint32) OPER_I_16(state);
 					return m68ki_read_16(ea);
 				}
 				case 1:		// (xxx).L
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					return m68ki_read_16(ea);
 				}
@@ -520,7 +521,7 @@ static uint16 READ_EA_16(int ea)
 				}
 				case 4:		// #<data>
 				{
-					return OPER_I_16();
+					return OPER_I_16(state);
 				}
 
 				default:	fatalerror("M68kFPU: READ_EA_16: unhandled mode %d, reg %d at %08X\n", mode, reg, REG_PC);
@@ -533,7 +534,7 @@ static uint16 READ_EA_16(int ea)
 	return 0;
 }
 
-static uint32 READ_EA_32(int ea)
+static uint32 READ_EA_32(m68ki_cpu_core *state, int ea)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -575,13 +576,13 @@ static uint32 READ_EA_32(int ea)
 			{
 				case 0:		// (xxx).W
 				{
-					uint32 ea = (uint32)OPER_I_16();
+					uint32 ea = (uint32) OPER_I_16(state);
 					return m68ki_read_32(ea);
 				}
 				case 1:		// (xxx).L
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					return m68ki_read_32(ea);
 				}
@@ -597,7 +598,7 @@ static uint32 READ_EA_32(int ea)
 				}
 				case 4:		// #<data>
 				{
-					return  OPER_I_32();
+					return OPER_I_32(state);
 				}
 				default:	fatalerror("M68kFPU: READ_EA_32: unhandled mode %d, reg %d at %08X\n", mode, reg, REG_PC);
 			}
@@ -608,7 +609,7 @@ static uint32 READ_EA_32(int ea)
 	return 0;
 }
 
-static uint64 READ_EA_64(int ea)
+static uint64 READ_EA_64(m68ki_cpu_core *state, int ea)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -659,8 +660,8 @@ static uint64 READ_EA_64(int ea)
 			{
 				case 1:     // (xxx).L
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					return (uint64)(m68ki_read_32(ea)) << 32 | (uint64)(m68ki_read_32(ea+4));
 				}
@@ -673,8 +674,8 @@ static uint64 READ_EA_64(int ea)
 				}
 				case 4:		// #<data>
 				{
-					h1 = OPER_I_32();
-					h2 = OPER_I_32();
+					h1 = OPER_I_32(state);
+					h2 = OPER_I_32(state);
 					return  (uint64)(h1) << 32 | (uint64)(h2);
 				}
 				case 2:		// (d16, PC)
@@ -695,7 +696,7 @@ static uint64 READ_EA_64(int ea)
 }
 
 
-static floatx80 READ_EA_FPE(uint32 ea)
+static floatx80 READ_EA_FPE(m68ki_cpu_core *state, uint32 ea)
 {
 	floatx80 fpr;
 	int mode = (ea >> 3) & 0x7;
@@ -745,8 +746,8 @@ static floatx80 READ_EA_FPE(uint32 ea)
 			{
 				case 1:     // (xxx)
 					{
-						uint32 d1 = OPER_I_16();
-						uint32 d2 = OPER_I_16();
+						uint32 d1 = OPER_I_16(state);
+						uint32 d2 = OPER_I_16(state);
 						uint32 ea = (d1 << 16) | d2;
 						fpr = load_extended_float80(ea);
 					}
@@ -787,7 +788,7 @@ static floatx80 READ_EA_FPE(uint32 ea)
 	return fpr;
 }
 
-static floatx80 READ_EA_PACK(int ea)
+static floatx80 READ_EA_PACK(m68ki_cpu_core *state, int ea)
 {
 	floatx80 fpr;
 	int mode = (ea >> 3) & 0x7;
@@ -834,7 +835,7 @@ static floatx80 READ_EA_PACK(int ea)
 	return fpr;
 }
 
-static void WRITE_EA_8(int ea, uint8 data)
+static void WRITE_EA_8(m68ki_cpu_core *state, int ea, uint8 data)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -882,8 +883,8 @@ static void WRITE_EA_8(int ea, uint8 data)
 			{
 				case 1:		// (xxx).B
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					m68ki_write_8(ea, data);
 					break;
@@ -902,7 +903,7 @@ static void WRITE_EA_8(int ea, uint8 data)
 	}
 }
 
-static void WRITE_EA_16(int ea, uint16 data)
+static void WRITE_EA_16(m68ki_cpu_core *state, int ea, uint16 data)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -950,8 +951,8 @@ static void WRITE_EA_16(int ea, uint16 data)
 			{
 				case 1:		// (xxx).W
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					m68ki_write_16(ea, data);
 					break;
@@ -970,7 +971,7 @@ static void WRITE_EA_16(int ea, uint16 data)
 	}
 }
 
-static void WRITE_EA_32(int ea, uint32 data)
+static void WRITE_EA_32(m68ki_cpu_core *state, int ea, uint32 data)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -1023,14 +1024,14 @@ static void WRITE_EA_32(int ea, uint32 data)
 			{
 				case 0:     // (xxx).W
 				{
-					uint32 ea = OPER_I_16();
+					uint32 ea = OPER_I_16(state);
 					m68ki_write_32(ea, data);
 					break;
 				}
 				case 1:		// (xxx).L
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					m68ki_write_32(ea, data);
 					break;
@@ -1049,7 +1050,7 @@ static void WRITE_EA_32(int ea, uint32 data)
 	}
 }
 
-static void WRITE_EA_64(int ea, uint64 data)
+static void WRITE_EA_64(m68ki_cpu_core *state, int ea, uint64 data)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -1100,8 +1101,8 @@ static void WRITE_EA_64(int ea, uint64 data)
 			{
 				case 1:     // (xxx).L
 				{
-					uint32 d1 = OPER_I_16();
-					uint32 d2 = OPER_I_16();
+					uint32 d1 = OPER_I_16(state);
+					uint32 d2 = OPER_I_16(state);
 					uint32 ea = (d1 << 16) | d2;
 					m68ki_write_32(ea+0, (uint32)(data >> 32));
 					m68ki_write_32(ea+4, (uint32)(data));
@@ -1122,7 +1123,7 @@ static void WRITE_EA_64(int ea, uint64 data)
 	}
 }
 
-static void WRITE_EA_FPE(uint32 ea, floatx80 fpr)
+static void WRITE_EA_FPE(m68ki_cpu_core *state, uint32 ea, floatx80 fpr)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -1173,7 +1174,7 @@ static void WRITE_EA_FPE(uint32 ea, floatx80 fpr)
 	}
 }
 
-static void WRITE_EA_PACK(int ea, int k, floatx80 fpr)
+static void WRITE_EA_PACK(m68ki_cpu_core *state, int ea, int k, floatx80 fpr)
 {
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
@@ -1219,7 +1220,7 @@ static void WRITE_EA_PACK(int ea, int k, floatx80 fpr)
 }
 
 
-static void fpgen_rm_reg(uint16 w2)
+static void fpgen_rm_reg(m68ki_cpu_core *state, uint16 w2)
 {
 	int ea = REG_IR & 0x3f;
 	int rm = (w2 >> 14) & 0x1;
@@ -1236,42 +1237,42 @@ static void fpgen_rm_reg(uint16 w2)
 		{
 			case 0:		// Long-Word Integer
 			{
-				sint32 d = READ_EA_32(ea);
+				sint32 d = READ_EA_32(state, ea);
 				source = int32_to_floatx80(d);
 				break;
 			}
 			case 1:		// Single-precision Real
 			{
-				uint32 d = READ_EA_32(ea);
+				uint32 d = READ_EA_32(state, ea);
 				source = float32_to_floatx80(d, &status);
 				break;
 			}
 			case 2:		// Extended-precision Real
 			{
-				source = READ_EA_FPE(ea);
+				source = READ_EA_FPE(state, ea);
 				break;
 			}
 			case 3:		// Packed-decimal Real
 			{
-				source = READ_EA_PACK(ea);
+				source = READ_EA_PACK(state, ea);
 				break;
 			}
 			case 4:		// Word Integer
 			{
-				sint16 d = READ_EA_16(ea);
+				sint16 d = READ_EA_16(state, ea);
 				source = int32_to_floatx80((sint32)d);
 				break;
 			}
 			case 5:		// Double-precision Real
 			{
-				uint64 d = READ_EA_64(ea);
+				uint64 d = READ_EA_64(state, ea);
 
 				source = float64_to_floatx80(d, &status);
 				break;
 			}
 			case 6:		// Byte Integer
 			{
-				sint8 d = READ_EA_8(ea);
+				sint8 d = READ_EA_8(state, ea);
 				source = int32_to_floatx80((sint32)d);
 				break;
 			}
@@ -1743,7 +1744,7 @@ static void fpgen_rm_reg(uint16 w2)
 	}
 }
 
-static void fmove_reg_mem(uint16 w2)
+static void fmove_reg_mem(m68ki_cpu_core *state, uint16 w2)
 {
 	int ea = REG_IR & 0x3f;
 	int src = (w2 >>  7) & 0x7;
@@ -1755,25 +1756,25 @@ static void fmove_reg_mem(uint16 w2)
 		case 0:		// Long-Word Integer
 		{
 			sint32 d = (sint32)floatx80_to_int32(REG_FP[src], &status);
-			WRITE_EA_32(ea, d);
+			WRITE_EA_32(state, ea, d);
 			break;
 		}
 		case 1:		// Single-precision Real
 		{
 			uint32 d = floatx80_to_float32(REG_FP[src], &status);
-			WRITE_EA_32(ea, d);
+			WRITE_EA_32(state, ea, d);
 			break;
 		}
 		case 2:		// Extended-precision Real
 		{
-			WRITE_EA_FPE(ea, REG_FP[src]);
+			WRITE_EA_FPE(state, ea, REG_FP[src]);
 			break;
 		}
 		case 3:		// Packed-decimal Real with Static K-factor
 		{
 			// sign-extend k
 			k = (k & 0x40) ? (k | 0xffffff80) : (k & 0x7f);
-			WRITE_EA_PACK(ea, k, REG_FP[src]);
+			WRITE_EA_PACK(state, ea, k, REG_FP[src]);
 			break;
 		}
 		case 4:		// Word Integer
@@ -1783,7 +1784,7 @@ static void fmove_reg_mem(uint16 w2)
 			{
 				REG_FPSR |= FPES_OE | FPAE_IOP;
 			}
-			WRITE_EA_16(ea, (sint16)value);
+			WRITE_EA_16(state, ea, (sint16) value);
 			break;
 		}
 		case 5:		// Double-precision Real
@@ -1792,7 +1793,7 @@ static void fmove_reg_mem(uint16 w2)
 
 			d = floatx80_to_float64(REG_FP[src], &status);
 
-			WRITE_EA_64(ea, d);
+			WRITE_EA_64(state, ea, d);
 			break;
 		}
 		case 6:		// Byte Integer
@@ -1802,12 +1803,12 @@ static void fmove_reg_mem(uint16 w2)
 			{
 				REG_FPSR |= FPES_OE | FPAE_IOP;
 			}
-			WRITE_EA_8(ea, (sint8)value);
+			WRITE_EA_8(state, ea, (sint8) value);
 			break;
 		}
 		case 7:		// Packed-decimal Real with Dynamic K-factor
 		{
-			WRITE_EA_PACK(ea, REG_D[k>>4], REG_FP[src]);
+			WRITE_EA_PACK(state, ea, REG_D[k >> 4], REG_FP[src]);
 			break;
 		}
 	}
@@ -1815,7 +1816,7 @@ static void fmove_reg_mem(uint16 w2)
 	USE_CYCLES(12);
 }
 
-static void fmove_fpcr(uint16 w2)
+static void fmove_fpcr(m68ki_cpu_core *state, uint16 w2)
 {
 	int ea = REG_IR & 0x3f;
 	int dir = (w2 >> 13) & 0x1;
@@ -1852,15 +1853,15 @@ static void fmove_fpcr(uint16 w2)
 	{
 		if (dir)    // From system control reg to <ea>
 		{
-			if (regsel & 4) WRITE_EA_32(ea, REG_FPCR);
-			if (regsel & 2) WRITE_EA_32(ea, REG_FPSR);
-			if (regsel & 1) WRITE_EA_32(ea, REG_FPIAR);
+			if (regsel & 4) WRITE_EA_32(state, ea, REG_FPCR);
+			if (regsel & 2) WRITE_EA_32(state, ea, REG_FPSR);
+			if (regsel & 1) WRITE_EA_32(state, ea, REG_FPIAR);
 		}
 		else        // From <ea> to system control reg
 		{
-			if (regsel & 4) REG_FPCR = READ_EA_32(ea);
-			if (regsel & 2) REG_FPSR = READ_EA_32(ea);
-			if (regsel & 1) REG_FPIAR = READ_EA_32(ea);
+			if (regsel & 4) REG_FPCR = READ_EA_32(state, ea);
+			if (regsel & 2) REG_FPSR = READ_EA_32(state, ea);
+			if (regsel & 1) REG_FPIAR = READ_EA_32(state, ea);
 		}
 	}
 
@@ -1915,7 +1916,7 @@ static void fmove_fpcr(uint16 w2)
 	USE_CYCLES(10);
 }
 
-static void fmovem(uint16 w2)
+static void fmovem(m68ki_cpu_core *state, uint16 w2)
 {
 	int i;
 	int ea = REG_IR & 0x3f;
@@ -1957,7 +1958,7 @@ static void fmovem(uint16 w2)
 								mem_addr += 12;
 								break;
 							default:
-								WRITE_EA_FPE(ea, REG_FP[i]);
+								WRITE_EA_FPE(state, ea, REG_FP[i]);
 								break;
 						}
 
@@ -1981,7 +1982,7 @@ static void fmovem(uint16 w2)
 								mem_addr += 12;
 								break;
 							default:
-								WRITE_EA_FPE(ea, REG_FP[7-i]);
+								WRITE_EA_FPE(state, ea, REG_FP[7 - i]);
 								break;
 						}
 
@@ -2017,7 +2018,7 @@ static void fmovem(uint16 w2)
 								mem_addr += 12;
 								break;
 							default:
-								REG_FP[7-i] = READ_EA_FPE(ea);
+								REG_FP[7-i] = READ_EA_FPE(state, ea);
 								break;
 						}
 						USE_CYCLES(2);
@@ -2031,20 +2032,20 @@ static void fmovem(uint16 w2)
 	}
 }
 
-static void fscc()
+static void fscc(m68ki_cpu_core *state)
 {
 	int ea = REG_IR & 0x3f;
-	int condition = (sint16)(OPER_I_16());
+	int condition = (sint16)(OPER_I_16(state));
 
-	WRITE_EA_8(ea, TEST_CONDITION(condition) ? 0xff : 0);
+	WRITE_EA_8(state, ea, TEST_CONDITION(condition) ? 0xff : 0);
 	USE_CYCLES(7);  // ???
 }
-static void fbcc16(void)
+static void fbcc16(m68ki_cpu_core *state)
 {
 	sint32 offset;
 	int condition = REG_IR & 0x3f;
 
-	offset = (sint16)(OPER_I_16());
+	offset = (sint16)(OPER_I_16(state));
 
 	// TODO: condition and jump!!!
 	if (TEST_CONDITION(condition))
@@ -2056,12 +2057,12 @@ static void fbcc16(void)
 	USE_CYCLES(7);
 }
 
-static void fbcc32(void)
+static void fbcc32(m68ki_cpu_core *state)
 {
 	sint32 offset;
 	int condition = REG_IR & 0x3f;
 
-	offset = OPER_I_32();
+	offset = OPER_I_32(state);
 
 	// TODO: condition and jump!!!
 	if (TEST_CONDITION(condition))
@@ -2074,7 +2075,7 @@ static void fbcc32(void)
 }
 
 
-void m68040_fpu_op0()
+void m68040_fpu_op0(m68ki_cpu_core *state)
 {
 	m68ki_cpu.fpu_just_reset = 0;
 
@@ -2082,33 +2083,33 @@ void m68040_fpu_op0()
 	{
 		case 0:
 		{
-			uint16 w2 = OPER_I_16();
+			uint16 w2 = OPER_I_16(state);
 			switch ((w2 >> 13) & 0x7)
 			{
 				case 0x0:	// FPU ALU FP, FP
 				case 0x2:	// FPU ALU ea, FP
 				{
-					fpgen_rm_reg(w2);
+					fpgen_rm_reg(state, w2);
 					break;
 				}
 
 				case 0x3:	// FMOVE FP, ea
 				{
-					fmove_reg_mem(w2);
+					fmove_reg_mem(state, w2);
 					break;
 				}
 
 				case 0x4:	// FMOVEM ea, FPCR
 				case 0x5:	// FMOVEM FPCR, ea
 				{
-					fmove_fpcr(w2);
+					fmove_fpcr(state, w2);
 					break;
 				}
 
 				case 0x6:	// FMOVEM ea, list
 				case 0x7:	// FMOVEM list, ea
 				{
-					fmovem(w2);
+					fmovem(state, w2);
 					break;
 				}
 
@@ -2125,7 +2126,7 @@ void m68040_fpu_op0()
 				printf("M68kFPU: unimplemented FDBcc main op %d with mode %d at %08X\n", (REG_IR >> 6) & 0x3, (REG_IR >> 3) & 0x7, REG_PC-4);
 				break;
 			default: // FScc (?)
-				fscc();
+				fscc(state);
 				return;
 			}
 			fatalerror("M68kFPU: unimplemented main op %d with mode %d at %08X\n", (REG_IR >> 6) & 0x3, (REG_IR >> 3) & 0x7, REG_PC-4);
@@ -2133,12 +2134,12 @@ void m68040_fpu_op0()
 		}
 		case 2:     // FBcc disp16
 		{
-			fbcc16();
+			fbcc16(state);
 			break;
 		}
 		case 3:     // FBcc disp32
 		{
-			fbcc32();
+			fbcc32(state);
 			break;
 		}
 
@@ -2146,7 +2147,7 @@ void m68040_fpu_op0()
 	}
 }
 
-static int perform_fsave(uint32 addr, int inc)
+static int perform_fsave(m68ki_cpu_core *state, uint32 addr, int inc)
 {
 	if(m68ki_cpu.cpu_type & CPU_TYPE_040)
 	{
@@ -2188,7 +2189,7 @@ static int perform_fsave(uint32 addr, int inc)
 }
 
 // FRESTORE on a NULL frame reboots the FPU - all registers to NaN, the 3 status regs to 0
-static void do_frestore_null(void)
+static void do_frestore_null(m68ki_cpu_core *state)
 {
 	int i;
 
@@ -2206,7 +2207,7 @@ static void do_frestore_null(void)
 	m68ki_cpu.fpu_just_reset = 1;
 }
 
-void m68040_do_fsave(uint32 addr, int reg, int inc)
+void m68040_do_fsave(m68ki_cpu_core *state, uint32 addr, int reg, int inc)
 {
 	if (m68ki_cpu.fpu_just_reset)
 	{
@@ -2215,13 +2216,13 @@ void m68040_do_fsave(uint32 addr, int reg, int inc)
 	else
 	{
 		// we normally generate an IDLE frame
-		int delta = perform_fsave(addr, inc);
+		int delta = perform_fsave(state, addr, inc);
 		if(reg != -1)
 			REG_A[reg] += delta;
 	}
 }
 
-void m68040_do_frestore(uint32 addr, int reg)
+void m68040_do_frestore(m68ki_cpu_core *state, uint32 addr, int reg)
 {
 	uint32 temp = m68ki_read_32(addr);
 	// check for nullptr frame
@@ -2254,11 +2255,11 @@ void m68040_do_frestore(uint32 addr, int reg)
 	}
 	else
 	{
-		do_frestore_null();
+		do_frestore_null(state);
 	}
 }
 
-void m68040_fpu_op1()
+void m68040_fpu_op1(m68ki_cpu_core *state)
 {
 	int ea = REG_IR & 0x3f;
 	int mode = (ea >> 3) & 0x7;
@@ -2273,27 +2274,27 @@ void m68040_fpu_op1()
 			{
 				case 2: // (An)
 					addr = REG_A[reg];
-					m68040_do_fsave(addr, -1, 1);
+					m68040_do_fsave(state, addr, -1, 1);
 					break;
 
 				case 3:	// (An)+
 					addr = EA_AY_PI_32();
 					printf("FSAVE mode %d, reg A%d=0x%08x\n",mode,reg,REG_A[reg]);
-					m68040_do_fsave(addr, -1, 1); // FIXME: -1 was reg
+					m68040_do_fsave(state, addr, -1, 1); // FIXME: -1 was reg
 					break;
 
 				case 4: // -(An)
 					addr = EA_AY_PD_32();
-					m68040_do_fsave(addr, reg, 0); // FIXME: -1 was reg
+					m68040_do_fsave(state, addr, reg, 0); // FIXME: -1 was reg
 					break;
 				case 5: // (D16, An)
 					addr = EA_AY_DI_16();
-					m68040_do_fsave(addr, -1, 1);
+					m68040_do_fsave(state, addr, -1, 1);
 					break;
 
 				case 6: // (An) + (Xn) + d8
 					addr = EA_AY_IX_16();
-					m68040_do_fsave(addr, -1, 1);
+					m68040_do_fsave(state, addr, -1, 1);
 					break;
 
 				case 7: //
@@ -2303,13 +2304,13 @@ void m68040_fpu_op1()
 						case 1:     // (abs32)
 						{
 							addr = EA_AL_32();
-							m68040_do_fsave(addr, -1, 1);
+							m68040_do_fsave(state, addr, -1, 1);
 							break;
 						}
 						case 2:     // (d16, PC)
 						{
 							addr = EA_PCDI_16();
-							m68040_do_fsave(addr, -1, 1);
+							m68040_do_fsave(state, addr, -1, 1);
 							break;
 						}
 						default:
@@ -2330,22 +2331,22 @@ void m68040_fpu_op1()
 			{
 				case 2: // (An)
 					addr = REG_A[reg];
-					m68040_do_frestore(addr, -1);
+					m68040_do_frestore(state, addr, -1);
 					break;
 
 				case 3:	// (An)+
 					addr = EA_AY_PI_32();
-					m68040_do_frestore(addr, reg);
+					m68040_do_frestore(state, addr, reg);
 					break;
 
 				case 5: // (D16, An)
 					addr = EA_AY_DI_16();
-					m68040_do_frestore(addr, -1);
+					m68040_do_frestore(state, addr, -1);
 					break;
 
 				case 6: // (An) + (Xn) + d8
 					addr = EA_AY_IX_16();
-					m68040_do_frestore(addr, -1);
+					m68040_do_frestore(state, addr, -1);
 					break;
 
 				case 7: //
@@ -2355,13 +2356,13 @@ void m68040_fpu_op1()
 						case 1:     // (abs32)
 						{
 							addr = EA_AL_32();
-							m68040_do_frestore(addr, -1);
+							m68040_do_frestore(state, addr, -1);
 							break;
 						}
 						case 2:     // (d16, PC)
 						{
 							addr = EA_PCDI_16();
-							m68040_do_frestore(addr, -1);
+							m68040_do_frestore(state, addr, -1);
 							break;
 						}
 						default:
@@ -2380,9 +2381,9 @@ void m68040_fpu_op1()
 	}
 }
 
-void m68881_ftrap()
+void m68881_ftrap(m68ki_cpu_core *state)
 {
-	uint16 w2  = OPER_I_16();
+	uint16 w2  = OPER_I_16(state);
 
 	// now check the condition
 	if (TEST_CONDITION(w2 & 0x3f))
@@ -2395,11 +2396,11 @@ void m68881_ftrap()
 		switch (REG_IR & 0x7)
 		{
 			case 2: // word operand
-				OPER_I_16();
+				OPER_I_16(state);
 				break;
 
 			case 3: // long word operand
-				OPER_I_32();
+				OPER_I_32(state);
 				break;
 
 			case 4: // no operand

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -2052,7 +2052,7 @@ static void fbcc16(m68ki_cpu_core *state)
 	if (TEST_CONDITION(state, condition))
 	{
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_branch_16(offset-2);
+		m68ki_branch_16(state, offset - 2);
 	}
 
 	USE_CYCLES(7);
@@ -2069,7 +2069,7 @@ static void fbcc32(m68ki_cpu_core *state)
 	if (TEST_CONDITION(state, condition))
 	{
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
-		m68ki_branch_32(offset-4);
+		m68ki_branch_32(state, offset - 4);
 	}
 
 	USE_CYCLES(7);

--- a/m68kmake.c
+++ b/m68kmake.c
@@ -880,11 +880,11 @@ void generate_opcode_handler(FILE* filep, body_struct* body, replace_struct* rep
 		add_replace_string(replace, ID_OPHANDLER_EA_AY_16, str);
 		sprintf(str, "EA_%s_32()", g_ea_info_table[ea_mode].ea_add);
 		add_replace_string(replace, ID_OPHANDLER_EA_AY_32, str);
-		sprintf(str, "OPER_%s_8()", g_ea_info_table[ea_mode].ea_add);
+		sprintf(str, "OPER_%s_8(state)", g_ea_info_table[ea_mode].ea_add);
 		add_replace_string(replace, ID_OPHANDLER_OPER_AY_8, str);
-		sprintf(str, "OPER_%s_16()", g_ea_info_table[ea_mode].ea_add);
+		sprintf(str, "OPER_%s_16(state)", g_ea_info_table[ea_mode].ea_add);
 		add_replace_string(replace, ID_OPHANDLER_OPER_AY_16, str);
-		sprintf(str, "OPER_%s_32()", g_ea_info_table[ea_mode].ea_add);
+		sprintf(str, "OPER_%s_32(state)", g_ea_info_table[ea_mode].ea_add);
 		add_replace_string(replace, ID_OPHANDLER_OPER_AY_32, str);
 	}
 

--- a/m68kmake.c
+++ b/m68kmake.c
@@ -785,7 +785,7 @@ void get_base_name(char* base_name, opcode_struct* op)
 /* Write the name of an opcode handler function */
 void write_function_name(FILE* filep, char* base_name)
 {
-	fprintf(filep, "static void %s(void)\n", base_name);
+	fprintf(filep, "static void %s(m68ki_cpu_core *state)\n", base_name);
 }
 
 void add_opcode_output_table_entry(opcode_struct* op, char* name)

--- a/m68kmmu.h
+++ b/m68kmmu.h
@@ -966,7 +966,7 @@ void m68851_pload(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 	else
 	{
 		MMULOG(("PLOAD with MMU disabled on MC68851\n"));
-		m68ki_exception_trap(57);
+		m68ki_exception_trap(state, 57);
 		return;
 	}
 }
@@ -1095,7 +1095,7 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 				{
 					logerror("MMU: TC invalid!\n");
 					m68ki_cpu.mmu_tc &= ~0x80000000;
-					m68ki_exception_trap(EXCEPTION_MMU_CONFIGURATION);
+					m68ki_exception_trap(state, EXCEPTION_MMU_CONFIGURATION);
 				} else {
 					m68ki_cpu.pmmu_enabled = 1;
 				}
@@ -1121,7 +1121,7 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 			// SRP type 0 is not allowed
 			if ((m68ki_cpu.mmu_srp_limit & 3) == 0)
 			{
-				m68ki_exception_trap(EXCEPTION_MMU_CONFIGURATION);
+				m68ki_exception_trap(state, EXCEPTION_MMU_CONFIGURATION);
 				return;
 			}
 
@@ -1139,7 +1139,7 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 			// CRP type 0 is not allowed
 			if ((m68ki_cpu.mmu_crp_limit & 3) == 0)
 			{
-				m68ki_exception_trap(EXCEPTION_MMU_CONFIGURATION);
+				m68ki_exception_trap(state, EXCEPTION_MMU_CONFIGURATION);
 				return;
 			}
 

--- a/m68kmmu.h
+++ b/m68kmmu.h
@@ -207,12 +207,12 @@ void pmmu_atc_flush(m68ki_cpu_core *state)
 	m68ki_cpu.mmu_atc_rr = 0;
 }
 
-int fc_from_modes(uint16 modes);
+int fc_from_modes(m68ki_cpu_core *state, uint16 modes);
 
 void pmmu_atc_flush_fc_ea(m68ki_cpu_core *state, uint16 modes)
 {
 	unsigned int fcmask = (modes >> 5) & 7;
-	unsigned int fc = fc_from_modes(modes) & fcmask;
+	unsigned int fc = fc_from_modes(state, modes) & fcmask;
 	unsigned int ps = (m68ki_cpu.mmu_tc >> 20) & 0xf;
 	unsigned int mode = (modes >> 10) & 7;
 	uint32 ea;
@@ -900,7 +900,7 @@ uint32 pmmu_translate_addr(m68ki_cpu_core *state, uint32 addr_in, uint16 rw)
 	return addr_out;
 }
 
-int fc_from_modes(uint16 modes)
+int fc_from_modes(m68ki_cpu_core *state, uint16 modes)
 {
 	if ((modes & 0x1f) == 0)
 	{
@@ -946,7 +946,7 @@ int fc_from_modes(uint16 modes)
 void m68851_pload(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 {
 	uint32 ltmp = DECODE_EA_32(state, ea);
-	int fc = fc_from_modes(modes);
+	int fc = fc_from_modes(state, modes);
 	uint16 rw = !!(modes & 0x200);
 
 	MMULOG(("%s: PLOAD%c addr=%08x, fc=%d\n", __func__, rw ? 'R' : 'W', ltmp, fc));
@@ -978,7 +978,7 @@ void m68851_ptest(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 
 	int level = (modes >> 10) & 7;
 	uint16 rw = !!(modes & 0x200);
-	int fc = fc_from_modes(modes);
+	int fc = fc_from_modes(state, modes);
 
 	MMULOG(("PMMU: PTEST%c (%04X) pc=%08x sp=%08x va=%08x fc=%x level=%x a=%d, areg=%d\n",
 			rw ? 'R' : 'W', modes, m68ki_cpu.ppc, REG_A[7], v_addr, fc, level,

--- a/m68kmmu.h
+++ b/m68kmmu.h
@@ -122,12 +122,12 @@ uint32 DECODE_EA_32(m68ki_cpu_core *state, int ea)
 
 void pmmu_set_buserror(m68ki_cpu_core *state, uint32 addr_in)
 {
-	if (!m_side_effects_disabled && ++m68ki_cpu.mmu_tmp_buserror_occurred == 1)
+	if (!m_side_effects_disabled && ++state->mmu_tmp_buserror_occurred == 1)
 	{
-		m68ki_cpu.mmu_tmp_buserror_address = addr_in;
-		m68ki_cpu.mmu_tmp_buserror_rw = m68ki_cpu.mmu_tmp_rw;
-		m68ki_cpu.mmu_tmp_buserror_fc = m68ki_cpu.mmu_tmp_fc;
-		m68ki_cpu.mmu_tmp_buserror_sz = m68ki_cpu.mmu_tmp_sz;
+		state->mmu_tmp_buserror_address = addr_in;
+		state->mmu_tmp_buserror_rw = state->mmu_tmp_rw;
+		state->mmu_tmp_buserror_fc = state->mmu_tmp_fc;
+		state->mmu_tmp_buserror_sz = state->mmu_tmp_sz;
 	}
 }
 
@@ -136,21 +136,21 @@ void pmmu_set_buserror(m68ki_cpu_core *state, uint32 addr_in)
 void pmmu_atc_add(m68ki_cpu_core *state, uint32 logical, uint32 physical, int fc, int rw)
 {
 	// get page size (i.e. # of bits to ignore); is 10 for Apollo
-	int ps = (m68ki_cpu.mmu_tc >> 20) & 0xf;
+	int ps = (state->mmu_tc >> 20) & 0xf;
 	uint32 atc_tag = M68K_MMU_ATC_VALID | ((fc & 7) << 24) | ((logical >> ps) << (ps - 8));
 	uint32 atc_data = (physical >> ps) << (ps - 8);
 
-	if (m68ki_cpu.mmu_tmp_sr & (M68K_MMU_SR_BUS_ERROR|M68K_MMU_SR_INVALID|M68K_MMU_SR_SUPERVISOR_ONLY))
+	if (state->mmu_tmp_sr & (M68K_MMU_SR_BUS_ERROR|M68K_MMU_SR_INVALID|M68K_MMU_SR_SUPERVISOR_ONLY))
 	{
 		atc_data |= M68K_MMU_ATC_BUSERROR;
 	}
 
-	if (m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT)
+	if (state->mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT)
 	{
 		atc_data |= M68K_MMU_ATC_WRITE_PR;
 	}
 
-	if (!rw && !(m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT))
+	if (!rw && !(state->mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT))
 	{
 		atc_data |= M68K_MMU_ATC_MODIFIED;
 	}
@@ -159,10 +159,10 @@ void pmmu_atc_add(m68ki_cpu_core *state, uint32 logical, uint32 physical, int fc
 	for (int i = 0; i < MMU_ATC_ENTRIES; i++)
 	{
 		// if tag bits and function code match, don't add
-		if (m68ki_cpu.mmu_atc_tag[i] == atc_tag)
+		if (state->mmu_atc_tag[i] == atc_tag)
 		{
-			MMULOG(("%s: hit, old %08x new %08x\n", __func__, m68ki_cpu.mmu_atc_data[i], atc_data));
-			m68ki_cpu.mmu_atc_data[i] = atc_data;
+			MMULOG(("%s: hit, old %08x new %08x\n", __func__, state->mmu_atc_data[i], atc_data));
+			state->mmu_atc_data[i] = atc_data;
 			return;
 		}
 	}
@@ -171,7 +171,7 @@ void pmmu_atc_add(m68ki_cpu_core *state, uint32 logical, uint32 physical, int fc
 	int found = -1;
 	for (int i = 0; i < MMU_ATC_ENTRIES; i++)
 	{
-		if (!(m68ki_cpu.mmu_atc_tag[i] & M68K_MMU_ATC_VALID))
+		if (!(state->mmu_atc_tag[i] & M68K_MMU_ATC_VALID))
 		{
 			found = i;
 			break;
@@ -181,30 +181,30 @@ void pmmu_atc_add(m68ki_cpu_core *state, uint32 logical, uint32 physical, int fc
 	// did we find an entry?  steal one by round-robin then
 	if (found == -1)
 	{
-		found = m68ki_cpu.mmu_atc_rr++;
+		found = state->mmu_atc_rr++;
 
-		if (m68ki_cpu.mmu_atc_rr >= MMU_ATC_ENTRIES)
+		if (state->mmu_atc_rr >= MMU_ATC_ENTRIES)
 		{
-			m68ki_cpu.mmu_atc_rr = 0;
+			state->mmu_atc_rr = 0;
 		}
 	}
 
 	// add the entry
 	MMULOG(("ATC[%2d] add: log %08x -> phys %08x (fc=%d) data=%08x\n",
 			found, (logical >> ps) << ps, (physical >> ps) << ps, fc, atc_data));
-	m68ki_cpu.mmu_atc_tag[found] = atc_tag;
-	m68ki_cpu.mmu_atc_data[found] = atc_data;
+	state->mmu_atc_tag[found] = atc_tag;
+	state->mmu_atc_data[found] = atc_data;
 }
 
 // pmmu_atc_flush: flush entire ATC
 // 7fff0003 001ffd10 80f05750 is what should load
 void pmmu_atc_flush(m68ki_cpu_core *state)
 {
-	MMULOG(("ATC flush: pc=%08x\n", m68ki_cpu.ppc));
-//	std::fill(std::begin(m68ki_cpu.mmu_atc_tag), std::end(m68ki_cpu.mmu_atc_tag), 0);
+	MMULOG(("ATC flush: pc=%08x\n", state->ppc));
+//	std::fill(std::begin(state->mmu_atc_tag), std::end(state->mmu_atc_tag), 0);
 	for(int i=0;i<MMU_ATC_ENTRIES;i++)
-		m68ki_cpu.mmu_atc_tag[i]=0;
-	m68ki_cpu.mmu_atc_rr = 0;
+		state->mmu_atc_tag[i]=0;
+	state->mmu_atc_rr = 0;
 }
 
 int fc_from_modes(m68ki_cpu_core *state, uint16 modes);
@@ -213,7 +213,7 @@ void pmmu_atc_flush_fc_ea(m68ki_cpu_core *state, uint16 modes)
 {
 	unsigned int fcmask = (modes >> 5) & 7;
 	unsigned int fc = fc_from_modes(state, modes) & fcmask;
-	unsigned int ps = (m68ki_cpu.mmu_tc >> 20) & 0xf;
+	unsigned int ps = (state->mmu_tc >> 20) & 0xf;
 	unsigned int mode = (modes >> 10) & 7;
 	uint32 ea;
 
@@ -228,29 +228,29 @@ void pmmu_atc_flush_fc_ea(m68ki_cpu_core *state, uint16 modes)
 		MMULOG(("flush by fc: %d, mask %d\n", fc, fcmask));
 		for(int i=0,e;i<MMU_ATC_ENTRIES;i++)
 		{
-			e=m68ki_cpu.mmu_atc_tag[i];
+			e=state->mmu_atc_tag[i];
 			if ((e & M68K_MMU_ATC_VALID) && ((e >> 24) & fcmask) == fc)
 			{
 				MMULOG(("flushing entry %08x\n", e));
-				m68ki_cpu.mmu_atc_tag[i] = 0;
+				state->mmu_atc_tag[i] = 0;
 			}
 		}
 		break;
 
 	case 6: // flush by fc + ea
 
-		ea = DECODE_EA_32(state, m68ki_cpu.ir);
+		ea = DECODE_EA_32(state, state->ir);
 		MMULOG(("flush by fc/ea: fc %d, mask %d, ea %08x\n", fc, fcmask, ea));
 		for(unsigned int i=0,e;i<MMU_ATC_ENTRIES;i++)
 		{
-			e=m68ki_cpu.mmu_atc_tag[i];
+			e=state->mmu_atc_tag[i];
 			if ((e & M68K_MMU_ATC_VALID) &&
 				(((e >> 24) & fcmask) == fc) &&
 //              (((e >> ps) << (ps - 8)) == ((ea >> ps) << (ps - 8))))
 				( (e << ps) == (ea >> 8 << ps) ))
 			{
 				MMULOG(("flushing entry %08x\n", e));
-				m68ki_cpu.mmu_atc_tag[i] = 0;
+				state->mmu_atc_tag[i] = 0;
 			}
 		}
 		break;
@@ -265,18 +265,18 @@ void pmmu_atc_flush_fc_ea(m68ki_cpu_core *state, uint16 modes)
 uint16 pmmu_atc_lookup(m68ki_cpu_core *state, uint32 addr_in, int fc, uint16 rw, uint32 *addr_out, int ptest)
 {
 	MMULOG(("%s: LOOKUP addr_in=%08x, fc=%d, ptest=%d, rw=%d\n", __func__, addr_in, fc, ptest,rw));
-	unsigned int ps = (m68ki_cpu.mmu_tc >> 20) & 0xf;
+	unsigned int ps = (state->mmu_tc >> 20) & 0xf;
 	uint32 atc_tag = M68K_MMU_ATC_VALID | ((fc & 7) << 24) | ((addr_in >> ps) << (ps - 8));
 
 	for (int i = 0; i < MMU_ATC_ENTRIES; i++)
 	{
 
-		if (m68ki_cpu.mmu_atc_tag[i] != atc_tag)
+		if (state->mmu_atc_tag[i] != atc_tag)
 		{
 			continue;
 		}
 		
-		uint32 atc_data = m68ki_cpu.mmu_atc_data[i];
+		uint32 atc_data = state->mmu_atc_data[i];
 
 		if (!ptest && !rw)
 		{
@@ -287,35 +287,35 @@ uint16 pmmu_atc_lookup(m68ki_cpu_core *state, uint32 addr_in, int fc, uint16 rw,
 			// entry, and creating a new entry with the M bit set.
 			if (!(atc_data & M68K_MMU_ATC_MODIFIED))
 			{
-				m68ki_cpu.mmu_atc_tag[i] = 0;
+				state->mmu_atc_tag[i] = 0;
 				continue;
 			}
 		}
 
-		m68ki_cpu.mmu_tmp_sr = 0;
+		state->mmu_tmp_sr = 0;
 		if (atc_data & M68K_MMU_ATC_MODIFIED)
 		{
-			m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_MODIFIED;
+			state->mmu_tmp_sr |= M68K_MMU_SR_MODIFIED;
 		}
 
 		if (atc_data & M68K_MMU_ATC_WRITE_PR)
 		{
-			m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_WRITE_PROTECT;
+			state->mmu_tmp_sr |= M68K_MMU_SR_WRITE_PROTECT;
 		}
 
 		if (atc_data & M68K_MMU_ATC_BUSERROR)
 		{
-			m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_BUS_ERROR|M68K_MMU_SR_INVALID;
+			state->mmu_tmp_sr |= M68K_MMU_SR_BUS_ERROR|M68K_MMU_SR_INVALID;
 		}
 		*addr_out = (atc_data << 8) | (addr_in & ~(((uint32)~0) << ps));
 		MMULOG(("%s: addr_in=%08x, addr_out=%08x, MMU SR %04x\n",
-				__func__, addr_in, *addr_out, m68ki_cpu.mmu_tmp_sr));
+				__func__, addr_in, *addr_out, state->mmu_tmp_sr));
 		return 1;
 	}
 	MMULOG(("%s: lookup failed\n", __func__));
 	if (ptest)
 	{
-		m68ki_cpu.mmu_tmp_sr = M68K_MMU_SR_INVALID;
+		state->mmu_tmp_sr = M68K_MMU_SR_INVALID;
 	}
 	return 0;
 }
@@ -350,7 +350,7 @@ uint16 pmmu_match_tt(m68ki_cpu_core *state, uint32 addr_in, int fc, uint32 tt, u
 		return 0;
 	}
 
-	m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_TRANSPARENT;
+	state->mmu_tmp_sr |= M68K_MMU_SR_TRANSPARENT;
 	return 1;
 }
 
@@ -388,7 +388,7 @@ void update_sr(m68ki_cpu_core *state, int type, uint32 tbl_entry, int fc, uint16
 	case M68K_MMU_DF_DT_PAGE:
 		if (tbl_entry & M68K_MMU_DF_MODIFIED)
 		{
-			m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_MODIFIED;
+			state->mmu_tmp_sr |= M68K_MMU_SR_MODIFIED;
 		}
 		/* FALLTHROUGH */
 
@@ -399,12 +399,12 @@ void update_sr(m68ki_cpu_core *state, int type, uint32 tbl_entry, int fc, uint16
 
 		if (tbl_entry & M68K_MMU_DF_WP)
 		{
-			m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_WRITE_PROTECT;
+			state->mmu_tmp_sr |= M68K_MMU_SR_WRITE_PROTECT;
 		}
 
 		if (_long && !(fc & 4) && (tbl_entry & M68K_MMU_DF_SUPERVISOR))
 		{
-			m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_SUPERVISOR_ONLY;
+			state->mmu_tmp_sr |= M68K_MMU_SR_SUPERVISOR_ONLY;
 		}
 		break;
 	default:
@@ -417,18 +417,18 @@ uint16 pmmu_walk_tables(m68ki_cpu_core *state, uint32 addr_in, int type, uint32 
 						uint32 *addr_out, int ptest)
 {
 	int level = 0;
-	uint32 bits = m68ki_cpu.mmu_tc & 0xffff;
-	int pagesize = (m68ki_cpu.mmu_tc >> 20) & 0xf;
-	int is = (m68ki_cpu.mmu_tc >> 16) & 0xf;
+	uint32 bits = state->mmu_tc & 0xffff;
+	int pagesize = (state->mmu_tc >> 20) & 0xf;
+	int is = (state->mmu_tc >> 16) & 0xf;
 	int bitpos = 12;
 	int resolved = 0;
 	int pageshift = is;
 
 	addr_in <<= is;
 
-	m68ki_cpu.mmu_tablewalk = 1;
+	state->mmu_tablewalk = 1;
 
-	if (m68ki_cpu.mmu_tc & M68K_MMU_TC_FCL)
+	if (state->mmu_tc & M68K_MMU_TC_FCL)
 	{
 		bitpos = 16;
 	}
@@ -447,8 +447,8 @@ uint16 pmmu_walk_tables(m68ki_cpu_core *state, uint32 addr_in, int type, uint32 
 		switch(type)
 		{
 			case M68K_MMU_DF_DT_INVALID:   // invalid, will cause MMU exception
-				m68ki_cpu.mmu_tmp_sr = M68K_MMU_SR_INVALID;
-				MMULOG(("PMMU: DT0 PC=%x (addr_in %08x -> %08x)\n", m68ki_cpu.ppc, addr_in, *addr_out));
+				state->mmu_tmp_sr = M68K_MMU_SR_INVALID;
+				MMULOG(("PMMU: DT0 PC=%x (addr_in %08x -> %08x)\n", state->ppc, addr_in, *addr_out));
 				resolved = 1;
 				break;
 
@@ -518,7 +518,7 @@ uint16 pmmu_walk_tables(m68ki_cpu_core *state, uint32 addr_in, int type, uint32 
 				break;
 		}
 
-		if (m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_BUS_ERROR)
+		if (state->mmu_tmp_sr & M68K_MMU_SR_BUS_ERROR)
 		{
 			// Bus error during page table walking is always fatal
 			resolved = 1;
@@ -527,13 +527,13 @@ uint16 pmmu_walk_tables(m68ki_cpu_core *state, uint32 addr_in, int type, uint32 
 
 		if (!ptest && !m_side_effects_disabled)
 		{
-			if (!rw && (m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT))
+			if (!rw && (state->mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT))
 			{
 				resolved = 1;
 				break;
 			}
 
-			if (!(fc & 4) && (m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_SUPERVISOR_ONLY))
+			if (!(fc & 4) && (state->mmu_tmp_sr & M68K_MMU_SR_SUPERVISOR_ONLY))
 			{
 				resolved = 1;
 				break;
@@ -545,10 +545,10 @@ uint16 pmmu_walk_tables(m68ki_cpu_core *state, uint32 addr_in, int type, uint32 
 	} while(level < limit && !resolved);
 
 
-	m68ki_cpu.mmu_tmp_sr &= 0xfff0;
-	m68ki_cpu.mmu_tmp_sr |= level;
-	MMULOG(("MMU SR after walk: %04X\n", m68ki_cpu.mmu_tmp_sr));
-	m68ki_cpu.mmu_tablewalk = 0;
+	state->mmu_tmp_sr &= 0xfff0;
+	state->mmu_tmp_sr |= level;
+	MMULOG(("MMU SR after walk: %04X\n", state->mmu_tmp_sr));
+	state->mmu_tablewalk = 0;
 	return resolved;
 }
 
@@ -562,12 +562,12 @@ uint32 pmmu_translate_addr_with_fc(m68ki_cpu_core *state, uint32 addr_in, uint8 
 
 	MMULOG(("%s: addr_in=%08x, fc=%d, ptest=%d, rw=%d, limit=%d, pload=%d\n",
 			__func__, addr_in, fc, ptest, rw, limit, pload));
-	m68ki_cpu.mmu_tmp_sr = 0;
+	state->mmu_tmp_sr = 0;
 
-	m68ki_cpu.mmu_last_logical_addr = addr_in;
+	state->mmu_last_logical_addr = addr_in;
 
-	if (pmmu_match_tt(state, addr_in, fc, m68ki_cpu.mmu_tt0, rw) ||
-		pmmu_match_tt(state, addr_in, fc, m68ki_cpu.mmu_tt1, rw) ||
+	if (pmmu_match_tt(state, addr_in, fc, state->mmu_tt0, rw) ||
+		pmmu_match_tt(state, addr_in, fc, state->mmu_tt1, rw) ||
 		fc == 7)
 	{
 		return addr_in;
@@ -581,10 +581,10 @@ uint32 pmmu_translate_addr_with_fc(m68ki_cpu_core *state, uint32 addr_in, uint8 
 
 	if (!ptest && !pload && pmmu_atc_lookup(state, addr_in, fc, rw, &addr_out, 0))
 	{
-		if ((m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_BUS_ERROR) || (!rw && (m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT)))
+		if ((state->mmu_tmp_sr & M68K_MMU_SR_BUS_ERROR) || (!rw && (state->mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT)))
 		{
 			MMULOG(("set atc hit buserror: addr_in=%08x, addr_out=%x, rw=%x, fc=%d, sz=%d\n",
-					addr_in, addr_out, m68ki_cpu.mmu_tmp_rw, m68ki_cpu.mmu_tmp_fc, m68ki_cpu.mmu_tmp_sz));
+					addr_in, addr_out, state->mmu_tmp_rw, state->mmu_tmp_fc, state->mmu_tmp_sz));
 			pmmu_set_buserror(state, addr_in);
 		}
 		return addr_out;
@@ -593,15 +593,15 @@ uint32 pmmu_translate_addr_with_fc(m68ki_cpu_core *state, uint32 addr_in, uint8 
 	int type;
 	uint32 tbl_addr;
 	// if SRP is enabled and we're in supervisor mode, use it
-	if ((m68ki_cpu.mmu_tc & M68K_MMU_TC_SRE) && (fc & 4))
+	if ((state->mmu_tc & M68K_MMU_TC_SRE) && (fc & 4))
 	{
-		tbl_addr = m68ki_cpu.mmu_srp_aptr & M68K_MMU_DF_ADDR_MASK;
-		type = m68ki_cpu.mmu_srp_limit & M68K_MMU_DF_DT;
+		tbl_addr = state->mmu_srp_aptr & M68K_MMU_DF_ADDR_MASK;
+		type = state->mmu_srp_limit & M68K_MMU_DF_DT;
 	}
 	else    // else use the CRP
 	{
-		tbl_addr = m68ki_cpu.mmu_crp_aptr & M68K_MMU_DF_ADDR_MASK;
-		type = m68ki_cpu.mmu_crp_limit & M68K_MMU_DF_DT;
+		tbl_addr = state->mmu_crp_aptr & M68K_MMU_DF_ADDR_MASK;
+		type = state->mmu_crp_limit & M68K_MMU_DF_DT;
 	}
 
 	if (!pmmu_walk_tables(state, addr_in, type, tbl_addr, fc, limit, rw, &addr_out, ptest))
@@ -616,13 +616,13 @@ uint32 pmmu_translate_addr_with_fc(m68ki_cpu_core *state, uint32 addr_in, uint8 
 		return addr_out;
 	}
 
-	if ((m68ki_cpu.mmu_tmp_sr & (M68K_MMU_SR_INVALID|M68K_MMU_SR_SUPERVISOR_ONLY)) ||
-			((m68ki_cpu.mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT) && !rw))
+	if ((state->mmu_tmp_sr & (M68K_MMU_SR_INVALID|M68K_MMU_SR_SUPERVISOR_ONLY)) ||
+			((state->mmu_tmp_sr & M68K_MMU_SR_WRITE_PROTECT) && !rw))
 	{
 
 		if (!pload)
 		{
-			MMULOG(("%s: set buserror (SR %04X)\n", __func__, m68ki_cpu.mmu_tmp_sr));
+			MMULOG(("%s: set buserror (SR %04X)\n", __func__, state->mmu_tmp_sr));
 			pmmu_set_buserror(state, addr_in);
 		}
 	}
@@ -634,7 +634,7 @@ uint32 pmmu_translate_addr_with_fc(m68ki_cpu_core *state, uint32 addr_in, uint8 
 	{
 		pmmu_atc_add(state, addr_in, addr_out, fc, rw && type != 1);
 	}
-	MMULOG(("PMMU: [%08x] => [%08x] (SR %04x)\n", addr_in, addr_out, m68ki_cpu.mmu_tmp_sr));
+	MMULOG(("PMMU: [%08x] => [%08x] (SR %04x)\n", addr_in, addr_out, state->mmu_tmp_sr));
 	return addr_out;
 }
 
@@ -645,20 +645,20 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 	uint32 addr_out, tt0, tt1;
 
 	addr_out = addr_in;
-	m68ki_cpu.mmu_tmp_sr = 0;
+	state->mmu_tmp_sr = 0;
 
 	// transparent translation registers are always in force even if the PMMU itself is disabled
 	// they don't do much in emulation because we never write out of order, but the write-protect and cache control features
 	// are emulatable, and apparently transparent translation regions skip the page table lookup.
 	if (fc & 1) // data, use DTT0/DTT1
 	{
-		tt0 = m68ki_cpu.mmu_dtt0;
-		tt1 = m68ki_cpu.mmu_dtt1;
+		tt0 = state->mmu_dtt0;
+		tt1 = state->mmu_dtt1;
 	}
 	else if (fc & 2)    // program, use ITT0/ITT1
 	{
-		tt0 = m68ki_cpu.mmu_itt0;
-		tt1 = m68ki_cpu.mmu_itt1;
+		tt0 = state->mmu_itt0;
+		tt1 = state->mmu_itt1;
 	}
 	else
 	{
@@ -676,7 +676,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		if ((addr_in & mask) == (tt0 & mask) && (fc & fcmask[(tt0 >> 13) & 3]) == fcmatch[(tt0 >> 13) & 3])
 		{
 			MMULOG(("TT0 match on address %08x (TT0 = %08x, mask = %08x)\n", addr_in, tt0, mask));
-			if ((tt0 & 4) && !m68ki_cpu.mmu_tmp_rw && !ptest)   // write protect?
+			if ((tt0 & 4) && !state->mmu_tmp_rw && !ptest)   // write protect?
 			{
 				pmmu_set_buserror(state, addr_in);
 			}
@@ -696,7 +696,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		if ((addr_in & mask) == (tt1 & mask) && (fc & fcmask[(tt1 >> 13) & 3]) == fcmatch[(tt1 >> 13) & 3])
 		{
 			MMULOG(("TT1 match on address %08x (TT0 = %08x, mask = %08x)\n", addr_in, tt1, mask));
-			if ((tt1 & 4) && !m68ki_cpu.mmu_tmp_rw && !ptest)   // write protect?
+			if ((tt1 & 4) && !state->mmu_tmp_rw && !ptest)   // write protect?
 			{
 				pmmu_set_buserror(state, addr_in);
 			}
@@ -705,7 +705,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		}
 	}
 
-	if (m68ki_cpu.pmmu_enabled)
+	if (state->pmmu_enabled)
 	{
 		uint32 root_idx = (addr_in >> 25) & 0x7f;
 		uint32 ptr_idx = (addr_in >> 18) & 0x7f;
@@ -716,11 +716,11 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		// select supervisor or user root pointer
 		if (fc & 4)
 		{
-			root_ptr = m68ki_cpu.mmu_srp_aptr + (root_idx<<2);
+			root_ptr = state->mmu_srp_aptr + (root_idx<<2);
 		}
 		else
 		{
-			root_ptr = m68ki_cpu.mmu_urp_aptr + (root_idx<<2);
+			root_ptr = state->mmu_urp_aptr + (root_idx<<2);
 		}
 
 		// get the root entry
@@ -739,7 +739,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 			// PTEST: any write protect bits set in the search tree will set W in SR
 			if ((ptest) && (root_entry & 4))
 			{
-				m68ki_cpu.mmu_tmp_sr |= 4;
+				state->mmu_tmp_sr |= 4;
 			}
 
 			pointer_ptr = (root_entry & ~0x1ff) + (ptr_idx<<2);
@@ -748,7 +748,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 			// PTEST: any write protect bits set in the search tree will set W in SR
 			if ((ptest) && (pointer_entry & 4))
 			{
-				m68ki_cpu.mmu_tmp_sr |= 4;
+				state->mmu_tmp_sr |= 4;
 			}
 
 			// update U bit on this pointer entry too
@@ -761,7 +761,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 			MMULOG(("pointer entry = %08x\n", pointer_entry));
 
 			// write protected by the root or pointer entries?
-			if ((((root_entry & 4) && !m68ki_cpu.mmu_tmp_rw) || ((pointer_entry & 4) && !m68ki_cpu.mmu_tmp_rw)) && !ptest)
+			if ((((root_entry & 4) && !state->mmu_tmp_rw) || ((pointer_entry & 4) && !state->mmu_tmp_rw)) && !ptest)
 			{
 				pmmu_set_buserror(state, addr_in);
 				return addr_in;
@@ -770,7 +770,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 			// is UDT valid on the pointer entry?
 			if (!(pointer_entry & 2) && !ptest)
 			{
-				logerror("Invalid pointer entry!  PC=%x, addr=%x\n", m68ki_cpu.ppc, addr_in);
+				logerror("Invalid pointer entry!  PC=%x, addr=%x\n", state->ppc, addr_in);
 				pmmu_set_buserror(state, addr_in);
 				return addr_in;
 			}
@@ -779,7 +779,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		}
 		else // throw an error
 		{
-			logerror("Invalid root entry!  PC=%x, addr=%x\n", m68ki_cpu.ppc, addr_in);
+			logerror("Invalid root entry!  PC=%x, addr=%x\n", state->ppc, addr_in);
 
 			if (!ptest)
 			{
@@ -790,7 +790,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		}
 
 		// now do the page lookup
-		if (m68ki_cpu.mmu_tc & 0x4000)  // 8k pages?
+		if (state->mmu_tc & 0x4000)  // 8k pages?
 		{
 			page_idx = (addr_in >> 13) & 0x1f;
 			page = addr_in & 0x1fff;
@@ -807,7 +807,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 
 		page_ptr = pointer_entry + (page_idx<<2);
 		page_entry = m68k_read_memory_32(page_ptr);
-		m68ki_cpu.mmu_last_page_entry_addr = page_ptr;
+		state->mmu_last_page_entry_addr = page_ptr;
 
 		MMULOG(("page_entry = %08x\n", page_entry));
 
@@ -815,12 +815,12 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		while ((page_entry & 3) == 2)
 		{
 			page_entry = m68k_read_memory_32(page_entry & ~0x3);
-			m68ki_cpu.mmu_last_page_entry_addr = (page_entry & ~0x3);
+			state->mmu_last_page_entry_addr = (page_entry & ~0x3);
 		}
-		m68ki_cpu.mmu_last_page_entry = page_entry;
+		state->mmu_last_page_entry = page_entry;
 
 		// is the page write protected or supervisor protected?
-		if ((((page_entry & 4) && !m68ki_cpu.mmu_tmp_rw) || ((page_entry & 0x80) && !(fc & 4))) && !ptest)
+		if ((((page_entry & 4) && !state->mmu_tmp_rw) || ((page_entry & 0x80) && !(fc & 4))) && !ptest)
 		{
 			pmmu_set_buserror(state, addr_in);
 			return addr_in;
@@ -829,7 +829,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 		switch (page_entry & 3)
 		{
 			case 0: // invalid
-				MMULOG(("Invalid page entry!  PC=%x, addr=%x\n", m68ki_cpu.ppc, addr_in));
+				MMULOG(("Invalid page entry!  PC=%x, addr=%x\n", state->ppc, addr_in));
 				if (!ptest)
 				{
 					pmmu_set_buserror(state, addr_in);
@@ -839,7 +839,7 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 
 			case 1:
 			case 3: // normal
-				if (m68ki_cpu.mmu_tc & 0x4000)  // 8k pages?
+				if (state->mmu_tc & 0x4000)  // 8k pages?
 				{
 					addr_out = (page_entry & ~0x1fff) | page;
 				}
@@ -853,23 +853,23 @@ uint32 pmmu_translate_addr_with_fc_040(m68ki_cpu_core *state, uint32 addr_in, ui
 					page_entry |= 0x8;  // always set the U bit
 
 					// if we're writing, the M bit comes into play
-					if (!m68ki_cpu.mmu_tmp_rw)
+					if (!state->mmu_tmp_rw)
 					{
 						page_entry |= 0x10; // set Modified
 					}
 
 					// if these updates resulted in a change, write the entry back where we found it
-					if (page_entry != m68ki_cpu.mmu_last_page_entry && !m_side_effects_disabled)
+					if (page_entry != state->mmu_last_page_entry && !m_side_effects_disabled)
 					{
-						m68ki_cpu.mmu_last_page_entry = page_entry;
-						m68k_write_memory_32(m68ki_cpu.mmu_last_page_entry_addr, m68ki_cpu.mmu_last_page_entry);
+						state->mmu_last_page_entry = page_entry;
+						m68k_write_memory_32(state->mmu_last_page_entry_addr, state->mmu_last_page_entry);
 					}
 				}
 				else
 				{
 					// page entry: UR G U1 U0 S CM CM M U W PDT
 					// SR:         B  G U1 U0 S CM CM M 0 W T R
-					m68ki_cpu.mmu_tmp_sr |= ((addr_out & ~0xfff) || (page_entry & 0x7f4));
+					state->mmu_tmp_sr |= ((addr_out & ~0xfff) || (page_entry & 0x7f4));
 				}
 				break;
 
@@ -888,13 +888,13 @@ uint32 pmmu_translate_addr(m68ki_cpu_core *state, uint32 addr_in, uint16 rw)
 {
 	uint32 addr_out;
 
-	if (CPU_TYPE_IS_040_PLUS(m68ki_cpu.cpu_type))
+	if (CPU_TYPE_IS_040_PLUS(state->cpu_type))
 	{
-		addr_out = pmmu_translate_addr_with_fc_040(state, addr_in, m68ki_cpu.mmu_tmp_fc, 0);
+		addr_out = pmmu_translate_addr_with_fc_040(state, addr_in, state->mmu_tmp_fc, 0);
 	}
 	else
 	{
-		addr_out = pmmu_translate_addr_with_fc(state, addr_in, m68ki_cpu.mmu_tmp_fc, rw, 7, 0, 0);
+		addr_out = pmmu_translate_addr_with_fc(state, addr_in, state->mmu_tmp_fc, rw, 7, 0, 0);
 		MMULOG(("ADDRIN %08X, ADDROUT %08X\n", addr_in, addr_out));
 	}
 	return addr_out;
@@ -904,15 +904,15 @@ int fc_from_modes(m68ki_cpu_core *state, uint16 modes)
 {
 	if ((modes & 0x1f) == 0)
 	{
-		return m68ki_cpu.sfc;
+		return state->sfc;
 	}
 
 	if ((modes & 0x1f) == 1)
 	{
-		return m68ki_cpu.dfc;
+		return state->dfc;
 	}
 
-	if (m68ki_cpu.cpu_type & CPU_TYPE_030)
+	if (state->cpu_type & CPU_TYPE_030)
 	{
 		// 68030 has 3 bits fc, but 68851 4 bits
 		if (((modes >> 3) & 3) == 1)
@@ -952,9 +952,9 @@ void m68851_pload(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 	MMULOG(("%s: PLOAD%c addr=%08x, fc=%d\n", __func__, rw ? 'R' : 'W', ltmp, fc));
 
 	// MC68851 traps if MMU is not enabled, 030 not
-	if (m68ki_cpu.pmmu_enabled || (m68ki_cpu.cpu_type & CPU_TYPE_030))
+	if (state->pmmu_enabled || (state->cpu_type & CPU_TYPE_030))
 	{
-		if (CPU_TYPE_IS_040_PLUS(m68ki_cpu.cpu_type))
+		if (CPU_TYPE_IS_040_PLUS(state->cpu_type))
 		{
 			pmmu_translate_addr_with_fc_040(state, ltmp, fc, 0);
 		}
@@ -981,10 +981,10 @@ void m68851_ptest(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 	int fc = fc_from_modes(state, modes);
 
 	MMULOG(("PMMU: PTEST%c (%04X) pc=%08x sp=%08x va=%08x fc=%x level=%x a=%d, areg=%d\n",
-			rw ? 'R' : 'W', modes, m68ki_cpu.ppc, REG_A[7], v_addr, fc, level,
+			rw ? 'R' : 'W', modes, state->ppc, REG_A[7], v_addr, fc, level,
 					(modes & 0x100) ? 1 : 0, (modes >> 5) & 7));
 
-	if (CPU_TYPE_IS_040_PLUS(m68ki_cpu.cpu_type))
+	if (CPU_TYPE_IS_040_PLUS(state->cpu_type))
 	{
 		p_addr = pmmu_translate_addr_with_fc_040(state, v_addr, fc, 1);
 	}
@@ -993,9 +993,9 @@ void m68851_ptest(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 		p_addr = pmmu_translate_addr_with_fc(state, v_addr, fc, rw, level, 1, 0);
 	}
 
-	m68ki_cpu.mmu_sr = m68ki_cpu.mmu_tmp_sr;
+	state->mmu_sr = state->mmu_tmp_sr;
 
-	MMULOG(("PMMU: PTEST result: %04x pa=%08x\n", m68ki_cpu.mmu_sr, p_addr));
+	MMULOG(("PMMU: PTEST result: %04x pa=%08x\n", state->mmu_sr, p_addr));
 	if (modes & 0x100)
 	{
 		int areg = (modes >> 5) & 7;
@@ -1008,30 +1008,30 @@ void m68851_pmove_get(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 	switch ((modes>>10) & 0x3f)
 	{
 	case 0x02: // transparent translation register 0
-		WRITE_EA_32(state, ea, m68ki_cpu.mmu_tt0);
-		MMULOG(("PMMU: pc=%x PMOVE from mmu_tt0=%08x\n", m68ki_cpu.ppc, m68ki_cpu.mmu_tt0));
+		WRITE_EA_32(state, ea, state->mmu_tt0);
+		MMULOG(("PMMU: pc=%x PMOVE from mmu_tt0=%08x\n", state->ppc, state->mmu_tt0));
 		break;
 	case 0x03: // transparent translation register 1
-		WRITE_EA_32(state, ea, m68ki_cpu.mmu_tt1);
-		MMULOG(("PMMU: pc=%x PMOVE from mmu_tt1=%08x\n", m68ki_cpu.ppc, m68ki_cpu.mmu_tt1));
+		WRITE_EA_32(state, ea, state->mmu_tt1);
+		MMULOG(("PMMU: pc=%x PMOVE from mmu_tt1=%08x\n", state->ppc, state->mmu_tt1));
 		break;
 	case 0x10:  // translation control register
-		WRITE_EA_32(state, ea, m68ki_cpu.mmu_tc);
-		MMULOG(("PMMU: pc=%x PMOVE from mmu_tc=%08x\n", m68ki_cpu.ppc, m68ki_cpu.mmu_tc));
+		WRITE_EA_32(state, ea, state->mmu_tc);
+		MMULOG(("PMMU: pc=%x PMOVE from mmu_tc=%08x\n", state->ppc, state->mmu_tc));
 		break;
 
 	case 0x12: // supervisor root pointer
-		WRITE_EA_64(state, ea, (uint64)m68ki_cpu.mmu_srp_limit<<32 | (uint64)m68ki_cpu.mmu_srp_aptr);
-		MMULOG(("PMMU: pc=%x PMOVE from SRP limit = %08x, aptr = %08x\n", m68ki_cpu.ppc, m68ki_cpu.mmu_srp_limit, m68ki_cpu.mmu_srp_aptr));
+		WRITE_EA_64(state, ea, (uint64)state->mmu_srp_limit<<32 | (uint64)state->mmu_srp_aptr);
+		MMULOG(("PMMU: pc=%x PMOVE from SRP limit = %08x, aptr = %08x\n", state->ppc, state->mmu_srp_limit, state->mmu_srp_aptr));
 		break;
 
 	case 0x13: // CPU root pointer
-		WRITE_EA_64(state, ea, (uint64)m68ki_cpu.mmu_crp_limit<<32 | (uint64)m68ki_cpu.mmu_crp_aptr);
-		MMULOG(("PMMU: pc=%x PMOVE from CRP limit = %08x, aptr = %08x\n", m68ki_cpu.ppc, m68ki_cpu.mmu_crp_limit, m68ki_cpu.mmu_crp_aptr));
+		WRITE_EA_64(state, ea, (uint64)state->mmu_crp_limit<<32 | (uint64)state->mmu_crp_aptr);
+		MMULOG(("PMMU: pc=%x PMOVE from CRP limit = %08x, aptr = %08x\n", state->ppc, state->mmu_crp_limit, state->mmu_crp_aptr));
 		break;
 
 	default:
-		logerror("680x0: PMOVE from unknown MMU register %x, PC %x\n", (modes>>10) & 7, m68ki_cpu.pc);
+		logerror("680x0: PMOVE from unknown MMU register %x, PC %x\n", (modes>>10) & 7, state->pc);
 		return;
 	}
 
@@ -1053,13 +1053,13 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 
 		if (((modes >> 10) & 7) == 2)
 		{
-			MMULOG(("WRITE TT0 = 0x%08x\n", m68ki_cpu.mmu_tt0));
-			m68ki_cpu.mmu_tt0 = temp;
+			MMULOG(("WRITE TT0 = 0x%08x\n", state->mmu_tt0));
+			state->mmu_tt0 = temp;
 		}
 		else if (((modes >> 10) & 7) == 3)
 		{
-			MMULOG(("WRITE TT1 = 0x%08x\n", m68ki_cpu.mmu_tt1));
-			m68ki_cpu.mmu_tt1 = temp;
+			MMULOG(("WRITE TT1 = 0x%08x\n", state->mmu_tt1));
+			state->mmu_tt1 = temp;
 		}
 		break;
 
@@ -1073,37 +1073,37 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 	/* no break */
 
 	case 1:
-		logerror("680x0: unknown PMOVE case 1, PC %x\n", m68ki_cpu.pc);
+		logerror("680x0: unknown PMOVE case 1, PC %x\n", state->pc);
 		break;
 
 	case 2:
 		switch ((modes >> 10) & 7)
 		{
 		case 0: // translation control register
-			m68ki_cpu.mmu_tc = READ_EA_32(state, ea);
-			MMULOG(("PMMU: TC = %08x\n", m68ki_cpu.mmu_tc));
+			state->mmu_tc = READ_EA_32(state, ea);
+			MMULOG(("PMMU: TC = %08x\n", state->mmu_tc));
 
-			if (m68ki_cpu.mmu_tc & 0x80000000)
+			if (state->mmu_tc & 0x80000000)
 			{
 				int bits = 0;
 				for (int shift = 20; shift >= 0; shift -= 4)
 				{
-					bits += (m68ki_cpu.mmu_tc >> shift) & 0x0f;
+					bits += (state->mmu_tc >> shift) & 0x0f;
 				}
 
-				if (bits != 32 || !((m68ki_cpu.mmu_tc >> 23) & 1))
+				if (bits != 32 || !((state->mmu_tc >> 23) & 1))
 				{
 					logerror("MMU: TC invalid!\n");
-					m68ki_cpu.mmu_tc &= ~0x80000000;
+					state->mmu_tc &= ~0x80000000;
 					m68ki_exception_trap(state, EXCEPTION_MMU_CONFIGURATION);
 				} else {
-					m68ki_cpu.pmmu_enabled = 1;
+					state->pmmu_enabled = 1;
 				}
 				MMULOG(("PMMU enabled\n"));
 			}
 			else
 			{
-				m68ki_cpu.pmmu_enabled = 0;
+				state->pmmu_enabled = 0;
 				MMULOG(("PMMU disabled\n"));
 			}
 
@@ -1115,11 +1115,11 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 
 		case 2: // supervisor root pointer
 			temp64 = READ_EA_64(state, ea);
-			m68ki_cpu.mmu_srp_limit = (temp64 >> 32) & 0xffffffff;
-			m68ki_cpu.mmu_srp_aptr = temp64 & 0xffffffff;
-			MMULOG(("PMMU: SRP limit = %08x aptr = %08x\n", m68ki_cpu.mmu_srp_limit, m68ki_cpu.mmu_srp_aptr));
+			state->mmu_srp_limit = (temp64 >> 32) & 0xffffffff;
+			state->mmu_srp_aptr = temp64 & 0xffffffff;
+			MMULOG(("PMMU: SRP limit = %08x aptr = %08x\n", state->mmu_srp_limit, state->mmu_srp_aptr));
 			// SRP type 0 is not allowed
-			if ((m68ki_cpu.mmu_srp_limit & 3) == 0)
+			if ((state->mmu_srp_limit & 3) == 0)
 			{
 				m68ki_exception_trap(state, EXCEPTION_MMU_CONFIGURATION);
 				return;
@@ -1133,11 +1133,11 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 
 		case 3: // CPU root pointer
 			temp64 = READ_EA_64(state, ea);
-			m68ki_cpu.mmu_crp_limit = (temp64 >> 32) & 0xffffffff;
-			m68ki_cpu.mmu_crp_aptr = temp64 & 0xffffffff;
-			MMULOG(("PMMU: CRP limit = %08x aptr = %08x\n", m68ki_cpu.mmu_crp_limit, m68ki_cpu.mmu_crp_aptr));
+			state->mmu_crp_limit = (temp64 >> 32) & 0xffffffff;
+			state->mmu_crp_aptr = temp64 & 0xffffffff;
+			MMULOG(("PMMU: CRP limit = %08x aptr = %08x\n", state->mmu_crp_limit, state->mmu_crp_aptr));
 			// CRP type 0 is not allowed
-			if ((m68ki_cpu.mmu_crp_limit & 3) == 0)
+			if ((state->mmu_crp_limit & 3) == 0)
 			{
 				m68ki_exception_trap(state, EXCEPTION_MMU_CONFIGURATION);
 				return;
@@ -1150,14 +1150,14 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 			break;
 
 		case 7: // MC68851 Access Control Register
-			if (m68ki_cpu.cpu_type == CPU_TYPE_020)
+			if (state->cpu_type == CPU_TYPE_020)
 			{
 				// DomainOS on Apollo DN3000 will only reset this to 0
 				uint16 mmu_ac = READ_EA_16(state, ea);
 				if (mmu_ac != 0)
 				{
 					MMULOG(("680x0 PMMU: pc=%x PMOVE to mmu_ac=%08x\n",
-							m68ki_cpu.ppc, mmu_ac));
+							state->ppc, mmu_ac));
 				}
 				break;
 			}
@@ -1165,14 +1165,14 @@ void m68851_pmove_put(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 			/* fall through */
 			/* no break */
 		default:
-			logerror("680x0: PMOVE to unknown MMU register %x, PC %x\n", (modes>>10) & 7, m68ki_cpu.pc);
+			logerror("680x0: PMOVE to unknown MMU register %x, PC %x\n", (modes>>10) & 7, state->pc);
 			break;
 		}
 		break;
 	case 3: // MMU status
 	{
 		uint32 temp = READ_EA_32(state, ea);
-		logerror("680x0: unsupported PMOVE %x to MMU status, PC %x\n", temp, m68ki_cpu.pc);
+		logerror("680x0: unsupported PMOVE %x to MMU status, PC %x\n", temp, state->pc);
 	}
 	break;
 	}
@@ -1198,18 +1198,18 @@ void m68851_pmove(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 	case 3: // MC68030 to/from status reg
 		if (modes & 0x200)
 		{
-			MMULOG(("%s: read SR = %04x\n", __func__, m68ki_cpu.mmu_sr));
-			WRITE_EA_16(state, ea, m68ki_cpu.mmu_sr);
+			MMULOG(("%s: read SR = %04x\n", __func__, state->mmu_sr));
+			WRITE_EA_16(state, ea, state->mmu_sr);
 		}
 		else
 		{
-			m68ki_cpu.mmu_sr = READ_EA_16(state, ea);
-			MMULOG(("%s: write SR = %04X\n", __func__, m68ki_cpu.mmu_sr));
+			state->mmu_sr = READ_EA_16(state, ea);
+			MMULOG(("%s: write SR = %04X\n", __func__, state->mmu_sr));
 		}
 		break;
 
 	default:
-		logerror("680x0: unknown PMOVE mode %x (modes %04x) (PC %x)\n", (modes >> 13) & 0x7, modes, m68ki_cpu.pc);
+		logerror("680x0: unknown PMOVE mode %x (modes %04x) (PC %x)\n", (modes >> 13) & 0x7, modes, state->pc);
 		break;
 
 	}
@@ -1219,27 +1219,27 @@ void m68851_pmove(m68ki_cpu_core *state, uint32 ea, uint16 modes)
 void m68851_mmu_ops(m68ki_cpu_core *state)
 {
 	uint16 modes;
-	uint32 ea = m68ki_cpu.ir & 0x3f;
+	uint32 ea = state->ir & 0x3f;
 
 	// catch the 2 "weird" encodings up front (PBcc)
-	if ((m68ki_cpu.ir & 0xffc0) == 0xf0c0)
+	if ((state->ir & 0xffc0) == 0xf0c0)
 	{
 		logerror("680x0: unhandled PBcc\n");
 		return;
 	}
-	else if ((m68ki_cpu.ir & 0xffc0) == 0xf080)
+	else if ((state->ir & 0xffc0) == 0xf080)
 	{
 		logerror("680x0: unhandled PBcc\n");
 		return;
 	}
-	else if ((m68ki_cpu.ir & 0xffe0) == 0xf500)
+	else if ((state->ir & 0xffe0) == 0xf500)
 	{
-		MMULOG(("68040 pflush: pc=%08x ir=%04x opmode=%d register=%d\n", REG_PC-4, m68ki_cpu.ir, (m68ki_cpu.ir >> 3) & 3, m68ki_cpu.ir & 7));
+		MMULOG(("68040 pflush: pc=%08x ir=%04x opmode=%d register=%d\n", REG_PC-4, state->ir, (state->ir >> 3) & 3, state->ir & 7));
 		pmmu_atc_flush(state);
 	}
 	else	// the rest are 1111000xxxXXXXXX where xxx is the instruction family
 	{
-		switch ((m68ki_cpu.ir>>9) & 0x7)
+		switch ((state->ir>>9) & 0x7)
 		{
 			case 0:
 				modes = OPER_I_16(state);
@@ -1281,7 +1281,7 @@ void m68851_mmu_ops(m68ki_cpu_core *state)
 				break;
 
 			default:
-				logerror("680x0: unknown PMMU instruction group %d\n", (m68ki_cpu.ir>>9) & 0x7);
+				logerror("680x0: unknown PMMU instruction group %d\n", (state->ir>>9) & 0x7);
 				break;
 		}
 	}
@@ -1297,11 +1297,11 @@ inline uint32 hmmu_translate_addr(uint32 addr_in)
 	addr_out = addr_in;
 
 	// check if LC 24-bit mode is enabled - this simply blanks out A31, the V8 ignores A30-24 always
-	if (m68ki_cpu.hmmu_enabled == M68K_HMMU_ENABLE_LC)
+	if (state->hmmu_enabled == M68K_HMMU_ENABLE_LC)
 	{
 		addr_out = addr_in & 0xffffff;
 	}
-	else if (m68ki_cpu.hmmu_enabled == M68K_HMMU_ENABLE_II) // the original II does a more complex translation
+	else if (state->hmmu_enabled == M68K_HMMU_ENABLE_II) // the original II does a more complex translation
 	{
 		addr_out = addr_in & 0xffffff;
 
@@ -1328,19 +1328,19 @@ inline uint32 hmmu_translate_addr(uint32 addr_in)
 
 int m68851_buserror(u32& addr)
 {
-	if (!m68ki_cpu.pmmu_enabled)
+	if (!state->pmmu_enabled)
 	{
 		return false;
 	}
 
-	if (m68ki_cpu.mmu_tablewalk)
+	if (state->mmu_tablewalk)
 	{
 		MMULOG(("buserror during table walk\n"));
-		m68ki_cpu.mmu_tmp_sr |= M68K_MMU_SR_BUS_ERROR|M68K_MMU_SR_INVALID;
+		state->mmu_tmp_sr |= M68K_MMU_SR_BUS_ERROR|M68K_MMU_SR_INVALID;
 		return true;
 	}
 
-	addr = m68ki_cpu.mmu_last_logical_addr;
+	addr = state->mmu_last_logical_addr;
 	return false;
 }
 */


### PR DESCRIPTION
Large change to pipe around m68ki_cpu_core *state and access CPU state using this pointer. Worth only about 2-5% performance on its own, but sets the stage for further optimizations.