### PR TITLE
Add checks to buptest and nprog

### DIFF
--- a/nprog.sh
+++ b/nprog.sh
@@ -1,1 +1,15 @@
-sudo openocd -f ./nprog/68new.cfg
+if pgrep -x "emulator" > /dev/null
+then
+    echo "PiStorm emulator is running, please stop it first"
+    exit 1
+fi
+echo "Flashing..."
+sudo openocd -f ./nprog/68new.cfg > nprog_log.txt 2>&1
+if [ $? -ne 0 ]
+then
+    echo "Flashing failed, please see nprog_log.txt for details"
+    exit 1
+else
+    echo "Flashing successful!"
+fi
+

--- a/nprog_240.sh
+++ b/nprog_240.sh
@@ -1,1 +1,15 @@
-sudo openocd -f ./nprog/68_240.cfg
+if pgrep -x "emulator" > /dev/null
+then
+    echo "PiStorm emulator is running, please stop it first"
+    exit 1
+fi
+echo "Flashing..."
+sudo openocd -f ./nprog/68_240.cfg > nprog_log.txt 2>&1
+if [ $? -ne 0 ]
+then
+    echo "Flashing failed, please see nprog_log.txt for details"
+    exit 1
+else
+    echo "Flashing successful!"
+fi
+

--- a/nprog_240_experimental.sh
+++ b/nprog_240_experimental.sh
@@ -1,1 +1,15 @@
-sudo openocd -f ./nprog/68_240_experimental.cfg
+if pgrep -x "emulator" > /dev/null
+then
+    echo "PiStorm emulator is running, please stop it first"
+    exit 1
+fi
+echo "Flashing..."
+sudo openocd -f ./nprog/68_240_experimental.cfg > nprog_log.txt 2>&1
+if [ $? -ne 0 ]
+then
+    echo "Flashing failed, please see nprog_log.txt for details"
+    exit 1
+else
+    echo "Flashing successful!"
+fi
+

--- a/nprog_experimental.sh
+++ b/nprog_experimental.sh
@@ -1,1 +1,15 @@
-sudo openocd -f ./nprog/68new_experimental.cfg
+if pgrep -x "emulator" > /dev/null
+then
+    echo "PiStorm emulator is running, please stop it first"
+    exit 1
+fi
+echo "Flashing..."
+sudo openocd -f ./nprog/68new_experimental.cfg > nprog_log.txt 2>&1
+if [ $? -ne 0 ]
+then
+    echo "Flashing failed, please see nprog_log.txt for details"
+    exit 1
+else
+    echo "Flashing successful!"
+fi
+


### PR DESCRIPTION
nprog now checks if emulator is running and gives a much clearer success
/ fail with a log file for the more verbose output.

Also buptest now won't run if emulator is running.