### PR TITLE
Add flash autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ For Amiga, there is currently no Gayle or IDE controller emulation available, bu
 Install OpenOCD:
 `sudo apt-get install openocd`
 
-Run the FPGA update with:
-`./nprog.sh` if you are using an EPM570 PiStorm board or `./nprog_240.sh` if you are using an EPM240 PiStorm board.
+Run the FPGA update with `./flash.sh`, this will automatically detect your CPLD version and flash appropriately.
 
 If successful "Flashing successful!" will appear, if not it will fail with "Flashing failed" and `nprog_log.txt` will be created with more details.

--- a/flash.sh
+++ b/flash.sh
@@ -1,0 +1,28 @@
+set -o pipefail
+if ! command -v openocd &> /dev/null
+then
+    echo "openocd is not installed, please run \"sudo apt install openocd\""
+    exit 1
+fi
+echo -ne "Detecting CPLD... "
+version=$(sudo openocd -f nprog/detect.cfg 2>/dev/null | awk 'FNR == 3 { print $4 }')
+if [ $? -ne 0 ]
+then
+	echo "Error detecting CPLD."
+	exit 1
+fi
+case $version in
+	"0x020a10dd")
+		echo "EPM240 detected!"
+		./nprog_240.sh
+		;;
+	"0x020a20dd")
+		echo "EPM570 detected!"
+		./nprog.sh
+		;;
+	*)
+		echo "Could not detect CPLD"
+		exit 1
+		;;
+esac
+

--- a/flash_experimental.sh
+++ b/flash_experimental.sh
@@ -1,0 +1,28 @@
+set -o pipefail
+if ! command -v openocd &> /dev/null
+then
+    echo "openocd is not installed, please run \"sudo apt install openocd\""
+    exit 1
+fi
+echo -ne "Detecting CPLD... "
+version=`sudo openocd -f nprog/detect.cfg 2>/dev/null | awk 'FNR == 3 { print $4 }'`
+if [ $? -ne 0 ]
+then
+	echo "Error detecting CPLD."
+	exit 1
+fi
+case $version in
+	"0x020a10dd")
+		echo "EPM240 detected!"
+		./nprog_240_experimental.sh
+		;;
+	"0x020a20dd")
+		echo "EPM570 detected!"
+		./nprog_experimental.sh
+		;;
+	*)
+		echo "Could not detect CPLD"
+		exit 1
+		;;
+esac
+

--- a/nprog/detect.cfg
+++ b/nprog/detect.cfg
@@ -1,0 +1,32 @@
+# this supports ECP5 Evaluation Board
+
+reset_config none
+adapter driver bcm2835gpio
+
+#bcm2835gpio_peripheral_base 0x20000000
+bcm2835gpio_peripheral_base 0x3F000000
+
+# Transition delay calculation: SPEED_COEFF/khz - SPEED_OFFSET
+# These depend on system clock, calibrated for stock 700MHz
+# bcm2835gpio_speed SPEED_COEFF SPEED_OFFSET
+#bcm2835gpio_speed_coeffs 146203 36
+bcm2835gpio_speed_coeffs 194938 48
+
+#bcm2835gpio_peripheral_base 0x3F000000
+#bcm2835gpio_speed_coeffs 194938 48
+
+reset_config none
+adapter speed 100
+
+# JTAG                tck tms tdi tdo
+bcm2835gpio_jtag_nums 26 24   27  25
+
+#meh dummy reset to make openocd happy, set to A0 on SMI
+bcm2835gpio_srst_num 5
+reset_config srst_only srst_open_drain
+
+transport select jtag
+jtag newtap max2 tap -irlen 11
+init
+puts [scan_chain]
+shutdown


### PR DESCRIPTION
Added flash.sh and flash_experimental.sh. These will detect the CPLD
version for EPM240(G) and EPM570(G) and execute the correct flash
command.