### PR TITLE
Fix flash for sudo

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -o pipefail
 if ! command -v openocd &> /dev/null
 then

--- a/flash_experimental.sh
+++ b/flash_experimental.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -o pipefail
 if ! command -v openocd &> /dev/null
 then


### PR DESCRIPTION
When executed under sudo the wrong shell is used by Debian, causing an
error. This patch fixes the script so it specifies which shell to use.

Note that you don't need to run flash.sh under sudo because it sudos
itself.