### PR TITLE
Fix CPLD detection sometimes failing

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -o pipefail
+if pgrep -x "emulator" > /dev/null
+then
+    echo "PiStorm emulator is running, please stop it first"
+    exit 1
+fi
 if ! command -v openocd &> /dev/null
 then
     echo "openocd is not installed, please run \"sudo apt install openocd\""

--- a/flash_experimental.sh
+++ b/flash_experimental.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -o pipefail
+if pgrep -x "emulator" > /dev/null
+then
+    echo "PiStorm emulator is running, please stop it first"
+    exit 1
+fi
 if ! command -v openocd &> /dev/null
 then
     echo "openocd is not installed, please run \"sudo apt install openocd\""


### PR DESCRIPTION
CPLD detection would sometimes fail if emulator was running, so fail
with a message to stop the emulator _before_ detection. The emulator
check will remain in nprog too for those who run that directly.