### PR TITLE
Fix package IDs for nprog_240*.sh

### DIFF
--- a/nprog/68_240.cfg
+++ b/nprog/68_240.cfg
@@ -26,7 +26,7 @@ bcm2835gpio_srst_num 5
 reset_config srst_only srst_open_drain
 
 transport select jtag
-jtag newtap max2 tap -irlen 11 -expected-id 0x020a20dd
+jtag newtap max2 tap -irlen 11 -expected-id 0x020a10dd
 init
 svf ./rtl/EPM240_bitstream.svf -quiet
 sleep 200

--- a/nprog/68_240_experimental.cfg
+++ b/nprog/68_240_experimental.cfg
@@ -26,7 +26,7 @@ bcm2835gpio_srst_num 5
 reset_config srst_only srst_open_drain
 
 transport select jtag
-jtag newtap max2 tap -irlen 11 -expected-id 0x020a20dd
+jtag newtap max2 tap -irlen 11 -expected-id 0x020a10dd
 init
 svf ./rtl/EPM240_experimental.svf -quiet
 sleep 200


### PR DESCRIPTION
Since we are still logging stuff, lets fix the IDs for nprog_240*.sh so
that it doesn't fire an error for the config expecting to see an EPM570.