### PR TITLE
Add DF1-3 bootselect, Add option to move slow ram to chip ram

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -79,3 +79,10 @@ keyboard k nograb noautoconnect
 # Syntax is mouse [device] [toggle key] [autoconnect|noautoconnect]
 # (see "keyboard" above for autoconnect description)
 mouse /dev/input/mice m noautoconnect
+
+# Uncommenting below moves slow ram to the chip ram giving 1MB of chip ram
+# NOTE: Requires a 1MB ECS Agnus (8372) and a trapdoor memory expansion!
+#setvar move-slow-to-chip
+
+# Swap DF0 with DF1/2/3 - Useful for Kickstart 1.x / Trackloader games that will only boot from DF0
+#setvar swap-df0-df 1

--- a/platforms/amiga/amiga-registers.h
+++ b/platforms/amiga/amiga-registers.h
@@ -36,11 +36,17 @@ void adjust_gayle_1200();
 #define CIAAICR 0xBFED01
 #define CIAACRA 0xBFEE01
 #define CIAACRB 0xBFEF01
+
+#define CIABPRA 0xBFD000
+#define CIABPRB 0xBFD100
+
 #define POTGOR  0xDFF016
 #define SERDAT  0xDFF030
 
 #define DMACON  0xDFF096
 #define DMACONR 0xDFF002
+
+#define SEL0_BITNUM 3
 
 /* RAMSEY ADDRESSES */
 #define RAMSEY_REG 0xDE0003 /* just a nibble, it should return 0x08 for defaults with 16MB */


### PR DESCRIPTION
Hi,

* Adds functionality to switch DF0 with one of DF1/2/3 to allow booting from these drives in Kick 1.2/1.3 or with trackloader games that only support DF0
* Adds ability to move slowram down to chipram area without having to change JP2 to do so.

The slow to chip function checks if there is a 1MB capable Agnus - if not it disables itself
This function works similar to JP2 in the A500, this jumper simply connects either A23 or A19 to Agnus' A19 input.

When JP2 is set to A23 this causes the first 512K to be mirrored at 0x080000-0x0FFFFF because A23 is low from 0x0-0x800000, but since A23 is high on accesses to 0xC00000-0xC7FFFF these memory addresses select the upper 512K bank.

When enabled this feature simply redirects accesses over to the 0xC00000 space and blackholes normal access to 0xC00000-0xC7FFFF to prevent Kickstart detecting memory at both the 2nd 512K chipram bank and at slow ram area.

Since the 1MB Agnus has no higher address input than it's A19 pin it is not even aware of the difference between these two areas aside from whether A19 input is high or low 

