### PR TITLE
slow-to-chip: Fixup agnus detection

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -45,6 +45,7 @@ int cpu_emulation_running = 1;
 int swap_df0_with_dfx = 0;
 int spoof_df0_id = 0;
 int move_slow_to_chip = 0;
+int force_move_slow_to_chip = 0;
 
 uint8_t mouse_dx = 0, mouse_dy = 0;
 uint8_t mouse_buttons = 0;

--- a/platforms/amiga/amiga-registers.h
+++ b/platforms/amiga/amiga-registers.h
@@ -43,6 +43,8 @@ void adjust_gayle_1200();
 #define POTGOR  0xDFF016
 #define SERDAT  0xDFF030
 
+#define VPOSR   0xDFF004
+#define VPOSW   0xDFF02A
 #define DMACON  0xDFF096
 #define DMACONR 0xDFF002
 


### PR DESCRIPTION
Write to VPOSW before reading Agnus id seems to fix cold boot Agnus id read failure

Add "force-move-slow-to-chip" config option to force-disable Agnus check in case issue persists