### PR TITLE
Drop incoming frames without corresponding read requests.

### DIFF
--- a/a314/software-amiga/ethernet_pistorm/device-2.c
+++ b/a314/software-amiga/ethernet_pistorm/device-2.c
@@ -392,10 +392,10 @@ static void complete_read_reqs()
 		if (ios2)
 		{
 			copy_from_bd_and_reply(ios2, bd);
-
-			Remove((struct Node *)bd);
-			AddTail(&et_rbuf_free_list, (struct Node *)bd);
 		}
+
+		Remove((struct Node *)bd);
+		AddTail(&et_rbuf_free_list, (struct Node *)bd);
 	}
 	Permit();
 }


### PR DESCRIPTION
This solves the problem where the Amiga stops reading frames from the
network due to all buffers being allocated to unwanted frames.

Thanks to Niklas Ekström for helping finding this bug.