### PR TITLE
Add DPMS to RTG

### DIFF
--- a/amiga.cfg
+++ b/amiga.cfg
@@ -47,6 +47,8 @@ platform amiga
 #setvar enable_rtc_emulation 0
 # Uncomment to enable RTG
 #setvar rtg
+# Uncomment to enable DPMS (monitor turns off) when RTG sleeps
+#setvar rtg-dpms
 
 # Uncomment to enable CDTV mode (not working, requires Kickstart 1.3+CDTV extended ROM)
 #setvar cdtv

--- a/platforms/amiga/amiga-platform.c
+++ b/platforms/amiga/amiga-platform.c
@@ -70,6 +70,7 @@ uint8_t rtg_enabled = 0, piscsi_enabled = 0, pinet_enabled = 0, kick13_mode = 0,
 uint8_t a314_emulation_enabled = 0, a314_initialized = 0;
 
 extern uint32_t piscsi_base, pistorm_dev_base;
+extern uint8_t rtg_dpms;
 
 extern void stop_cpu_emulation(uint8_t disasm_cur);
 
@@ -443,7 +444,11 @@ void setvar_amiga(struct emulator_config *cfg, char *var, char *val) {
             adjust_ranges_amiga(cfg);
         }
         else
-            printf("[AMIGA} Failed to enable RTG.\n");
+            printf("[AMIGA] Failed to enable RTG.\n");
+    }
+    if (CHKVAR("rtg-dpms")) {
+        rtg_dpms = 1;
+        printf("[AMIGA] DPMS enabled for RTG.\n");
     }
     if CHKVAR("kick13") {
         printf("[AMIGA] Kickstart 1.3 mode enabled, Z3 PICs will not be enumerated.\n");


### PR DESCRIPTION
This uses the Pi monitor control to turn the monitor off and on. Turning
on requires a full reinit of RTG including creating a new InitWindow so
the reinit functionality has been changed slightly.

Original "RTG is currently sleeping" is still there in case monitor
doesn't support DPMS.