### PR TITLE
Fix Amiga reboot when DPMS is on

### DIFF
--- a/platforms/amiga/rtg/rtg-output-raylib.c
+++ b/platforms/amiga/rtg/rtg-output-raylib.c
@@ -412,11 +412,11 @@ void rtg_set_clut_entry(uint8_t index, uint32_t xrgb) {
 void rtg_init_display() {
     int err;
     rtg_on = 1;
-    if (rtg_dpms) {
-        vc_tv_hdmi_power_on_preferred();
-    }
 
     if (!rtg_initialized) {
+        if (rtg_dpms) {
+            vc_tv_hdmi_power_on_preferred();
+        }
         err = pthread_create(&thread_id, NULL, &rtgThread, (void *)&rtg_share_data);
         if (err != 0) {
             rtg_on = 0;
@@ -437,6 +437,7 @@ void rtg_shutdown_display() {
     if (rtg_dpms) {
         shutdown = 1;
         vc_tv_power_off();
+        pthread_join(thread_id, NULL);
     }
 
     rtg_on = 0;


### PR DESCRIPTION
When the Amiga reboots with DPMS enabled but not asleep the HDMI is
reset which breaks the Raylib window.

This patch only resets the HDMI if the thread has been stopped first.

Also fix thread leak when DPMS terminates the RTG thread.