### PR TITLE
When using Smooth Filtering on a RTG mode that is not compatible it will revert to Non Filtered output.

### DIFF
--- a/platforms/amiga/rtg/rtg-output-raylib.c
+++ b/platforms/amiga/rtg/rtg-output-raylib.c
@@ -198,7 +198,7 @@ void *rtgThread(void *args) {
     printf("RTG thread running\n");
     fflush(stdout);
 
-    int reinit = 0, old_filter_mode = -1;
+    int reinit = 0, old_filter_mode = -1, force_filter_mode = 0;
     rtg_on = 1;
 
     uint32_t *indexed_buf = NULL;
@@ -300,7 +300,22 @@ reinit_raylib:;
                 SetTextureFilter(raylib_texture, filter_mode);
                 SetTextureFilter(raylib_cursor_texture, filter_mode);
             }
-
+            /* If we are not in 16bit mode then don't use any filtering - otherwise force_filter_mode to no smoothing */
+            if (force_filter_mode == 0) {
+                if (format != RTGFMT_RBG565 && filter_mode != 0) {
+                    printf("Turning Smooth filtering off - display mode not 16bit\n");
+                    force_filter_mode = 1;
+                    old_filter_mode = filter_mode;
+                    SetTextureFilter(raylib_texture, 0);
+                    SetTextureFilter(raylib_cursor_texture, 0);
+            	}
+            } else {
+                if (format == RTGFMT_RBG565) {
+                    printf("Turning Smooth filtering back on - display mode is 16bit\n");
+		    force_filter_mode = 0;
+                    old_filter_mode = -1;
+                }
+            }
             BeginDrawing();
             rtg_output_in_vblank = 0;
             updating_screen = 1;


### PR DESCRIPTION
When using Smooth Filtering on a RTG mode that is not compatible it will revert to Non Filtered output.